### PR TITLE
Fix memory leak in get_db_comparator_name

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2663,7 +2663,9 @@ impl ExportImportFilesMetaData {
         unsafe {
             let c_name =
                 ffi::rocksdb_export_import_files_metadata_get_db_comparator_name(self.inner);
-            from_cstr(c_name)
+            let name = from_cstr(c_name);
+            ffi::rocksdb_free(c_name as *mut c_void);
+            name
         }
     }
 


### PR DESCRIPTION
ExportImportFilesMetaData::get_db_comparator_name now deallocates C FFI-allocated string using rocksdb_free, after creating a Rust-managed copy.

Related: https://github.com/restatedev/rocksdb/pull/4