### PR TITLE
Add EventListener support for OnFlushCompleted

### DIFF
--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -1,0 +1,194 @@
+// Copyright 2025 Restate Software, Inc., Restate GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use libc::c_void;
+
+use crate::ffi::rocksdb_flushjobinfo_t;
+use crate::ffi_util::from_cstr;
+use crate::{ffi, Options};
+
+/// EventListener defining a set of callbacks from RocksDB
+///
+/// The EventListener trait contains a set of callback functions that will
+/// be called when a specific RocksDB event happens such as flush. It can
+/// be used as a building block for developing custom features.
+///
+/// ## Important
+///
+/// Callback functions should not run for an extended period before they
+/// return as this will slow down RocksDB.
+///
+/// ## Threading
+///
+/// All EventListener callback will be called using the
+/// actual thread that involves in that specific event. For example, it
+/// is the RocksDB background flush thread that does the actual flush to
+/// call EventListener::OnFlushCompleted().
+///
+/// ## Locking
+///
+/// All EventListener callbacks are designed to be called without
+/// the current thread holding any DB mutex. This is to prevent potential
+/// deadlock and performance issue when using EventListener callbacks
+/// in a complex way.
+pub trait EventListener {
+    /// A callback function to RocksDB which will be called whenever a
+    /// registered RocksDB flushes a file. The default implementation is
+    /// no-op.
+    ///
+    /// Note that the this function must be implemented in a way such that
+    /// it should not run for an extended period of time before the function
+    /// returns.  Otherwise, RocksDB may be blocked.
+    fn on_flush_completed(&self, _flush_job_info: FlushJobInfo) {}
+}
+
+impl<T: EventListener + ?Sized> EventListener for Arc<T> {
+    fn on_flush_completed(&self, flush_job_info: FlushJobInfo) {
+        (**self).on_flush_completed(flush_job_info);
+    }
+}
+
+impl<T: EventListener + ?Sized> EventListener for Box<T> {
+    fn on_flush_completed(&self, flush_job_info: FlushJobInfo) {
+        (**self).on_flush_completed(flush_job_info);
+    }
+}
+
+pub trait EventListenerExt {
+    /// Adds an EventListener whose callback functions will be called
+    /// when a specific RocksDB event happens.
+    fn add_event_listener<T>(&mut self, listener: T)
+    where
+        T: EventListener + Send + Sync + 'static;
+}
+
+impl EventListenerExt for Options {
+    fn add_event_listener<T>(&mut self, listener: T)
+    where
+        T: EventListener + Send + Sync + 'static,
+    {
+        unsafe {
+            let cb = Box::new(EventListenerCallback::new(listener));
+            let cb_ptr = Box::into_raw(cb) as *mut c_void;
+
+            let event_listener_ptr = ffi::rocksdb_event_listener_create(
+                cb_ptr,
+                Some(EventListenerCallback::<T>::destructor),
+            );
+
+            ffi::rocksdb_event_listener_set_on_flush_completed(
+                event_listener_ptr,
+                Some(EventListenerCallback::<T>::on_flush_completed),
+            );
+
+            // Takes ownership of the event listener, which will also drop the
+            // EventListenerCallback via the destructor callback
+            ffi::rocksdb_options_add_event_listener(self.inner, event_listener_ptr);
+        }
+    }
+}
+
+/// Flush information
+#[derive(Debug)]
+pub struct FlushJobInfo {
+    /// The name of the column family
+    pub cf_name: String,
+    /// The path to the newly created file
+    pub file_path: String,
+    /// The smallest sequence number in the newly created file
+    pub smallest_seqno: u64,
+    /// The largest sequence number in the newly created file
+    pub largest_seqno: u64,
+    /// Flush reason
+    pub flush_reason: FlushReason,
+}
+
+/// Flush reason
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum FlushReason {
+    Others = 0,
+    GetLiveFiles = 1,
+    ShutDown = 2,
+    ExternalFileIngestion = 3,
+    ManualCompaction = 4,
+    WriteBufferManager = 5,
+    WriteBufferFull = 6,
+    Test = 7,
+    DeleteFiles = 8,
+    AutoCompaction = 9,
+    ManualFlush = 10,
+    ErrorRecovery = 11,
+    ErrorRecoveryRetryFlush = 12,
+    WalFull = 13,
+    CatchUpAfterErrorRecovery = 14,
+}
+
+pub(crate) struct EventListenerCallback<T>
+where
+    T: EventListener,
+{
+    listener: T,
+}
+
+impl<T> EventListenerCallback<T>
+where
+    T: EventListener,
+{
+    pub fn new(listener: T) -> Self {
+        Self { listener }
+    }
+
+    pub unsafe extern "C" fn destructor(raw_cb: *mut c_void) {
+        drop(Box::from_raw(raw_cb as *mut Self));
+    }
+
+    pub unsafe extern "C" fn on_flush_completed(
+        raw_cb: *mut c_void,
+        flush_job_info: *const rocksdb_flushjobinfo_t,
+    ) {
+        let cf_name_ptr = ffi::rocksdb_flushjobinfo_cf_name(flush_job_info);
+        let cf_name = if cf_name_ptr.is_null() {
+            String::new()
+        } else {
+            from_cstr(cf_name_ptr)
+        };
+
+        let file_path_ptr = ffi::rocksdb_flushjobinfo_file_path(flush_job_info);
+        let file_path = if file_path_ptr.is_null() {
+            String::new()
+        } else {
+            from_cstr(file_path_ptr)
+        };
+
+        let smallest_seqno = ffi::rocksdb_flushjobinfo_smallest_seqno(flush_job_info);
+        let largest_seqno = ffi::rocksdb_flushjobinfo_largest_seqno(flush_job_info);
+        let flush_reason = std::mem::transmute::<libc::c_int, FlushReason>(
+            ffi::rocksdb_flushjobinfo_flushreason(flush_job_info),
+        );
+
+        let flush_job_info = FlushJobInfo {
+            cf_name,
+            file_path,
+            smallest_seqno,
+            largest_seqno,
+            flush_reason,
+        };
+
+        let cb = &mut *(raw_cb as *mut Self);
+        cb.listener.on_flush_completed(flush_job_info);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ mod db_iterator;
 mod db_options;
 mod db_pinnable_slice;
 mod env;
+pub mod event_listener;
 mod iter_range;
 pub mod merge_operator;
 pub mod perf;

--- a/tests/test_event_listener.rs
+++ b/tests/test_event_listener.rs
@@ -1,0 +1,132 @@
+// Copyright 2025 Restate Software, Inc., Restate GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod util;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use rust_rocksdb::event_listener::{EventListener, EventListenerExt, FlushJobInfo, FlushReason};
+use rust_rocksdb::{Options, DB};
+use util::DBPath;
+
+struct TestListener {
+    counters: RwLock<HashMap<String, u32>>,
+}
+
+impl TestListener {
+    fn new() -> Self {
+        TestListener {
+            counters: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl EventListener for TestListener {
+    fn on_flush_completed(&self, info: FlushJobInfo) {
+        assert_eq!(FlushReason::ManualFlush, info.flush_reason);
+        let mut counters = self.counters.write();
+        let cf_entry = counters.entry(info.cf_name.clone()).or_insert(0);
+        *cf_entry += 1;
+    }
+}
+
+#[test]
+pub fn test_event_listener() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_event_listener_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db1"));
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+
+    let listener = Arc::new(TestListener::new());
+
+    opts.add_event_listener(listener.clone());
+    assert_eq!(0, listener.counters.read().len());
+
+    let db = DB::open_cf_with_opts(
+        &opts,
+        &db_path,
+        vec![("cf1", Options::default()), ("cf2", Options::default())],
+    )
+    .unwrap();
+
+    let cf1 = db.cf_handle("cf1").unwrap();
+    db.put_cf(&cf1, b"k1", b"").unwrap();
+    db.flush_cf(&cf1).unwrap();
+    assert_eq!(
+        1,
+        listener
+            .counters
+            .read()
+            .get("cf1")
+            .copied()
+            .unwrap_or_default()
+    );
+    assert_eq!(1, listener.counters.read().len());
+
+    db.put_cf(&cf1, b"k2", b"").unwrap();
+    db.flush_cf(&cf1).unwrap();
+    assert_eq!(
+        2,
+        listener
+            .counters
+            .read()
+            .get("cf1")
+            .copied()
+            .unwrap_or_default()
+    );
+
+    db.put_cf(&cf1, "k3", b"").unwrap();
+    db.flush_cf(&cf1).unwrap();
+    db.flush_cf(&cf1).unwrap(); // no-op
+    db.flush_cf(&cf1).unwrap(); // no-op
+    assert_eq!(
+        3,
+        listener
+            .counters
+            .read()
+            .get("cf1")
+            .copied()
+            .unwrap_or_default()
+    );
+    assert_eq!(1, listener.counters.read().len());
+
+    let cf2 = db.cf_handle("cf2").unwrap();
+    db.put_cf(&cf2, b"k4", b"").unwrap();
+    db.flush_cf(&cf2).unwrap();
+    assert_eq!(
+        3,
+        listener
+            .counters
+            .read()
+            .get("cf1")
+            .copied()
+            .unwrap_or_default()
+    );
+    assert_eq!(
+        1,
+        listener
+            .counters
+            .read()
+            .get("cf2")
+            .copied()
+            .unwrap_or_default()
+    );
+    assert_eq!(2, listener.counters.read().len());
+}


### PR DESCRIPTION
This PR implements Rust bindings for the RocksDB EventListener feature, specifically focusing on the OnFlushCompleted event.

- A new event_listener module provides the EventListener trait and FFI callback handling
- Updates the RocksDB submodule to point to the version containing the C FFI additions

Depends on: https://github.com/restatedev/rocksdb/pull/7

---

Additional testing:

```
pavel@ubuntu:/Users/pavel/restate/rust-rocksdb$ cargo valgrind nextest run --no-capture event_listener
   Compiling rust-librocksdb-sys v0.36.0+10.1.3 (/Users/pavel/restate/rust-rocksdb/librocksdb-sys)
   Compiling rust-rocksdb v0.40.0-restate.1 (/Users/pavel/restate/rust-rocksdb)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 01s
info: using target runner `/home/pavel/.cargo/bin/cargo-valgrind` defined by environment variable `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER`
────────────
 Nextest run ID 1425641b-5aeb-49b7-beb0-94d07dfca5fe with nextest profile: default
    Starting 1 test across 25 binaries (196 tests skipped)
       START             rust-rocksdb::test_event_listener test_event_listener

running 1 test
test test_event_listener ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.72s

        PASS [   3.405s] rust-rocksdb::test_event_listener test_event_listener
────────────
     Summary [   3.418s] 1 test run: 1 passed, 196 skipped
```