### PR TITLE
Add TablePropertiesCollector support

### DIFF
--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -172,6 +172,32 @@ impl FlushJobInfo<'_> {
             Some(value_string)
         }
     }
+
+    pub fn get_user_collected_property_keys(&self) -> Vec<CString> {
+        unsafe {
+            let mut key_count: usize = 0;
+            let keys_ptr = ffi::rocksdb_table_properties_get_user_collected_property_keys(
+                self.table_properties.as_ptr(),
+                &mut key_count,
+            );
+
+            if keys_ptr.is_null() {
+                return Vec::new();
+            }
+
+            let mut result = Vec::with_capacity(key_count);
+            for i in 0..key_count {
+                let key_ptr = *keys_ptr.add(i);
+                if !key_ptr.is_null() {
+                    result.push(CStr::from_ptr(key_ptr).to_owned());
+                    ffi::rocksdb_free(key_ptr as *mut c_void);
+                }
+            }
+            ffi::rocksdb_free(keys_ptr as *mut c_void);
+
+            result
+        }
+    }
 }
 
 pub(crate) struct EventListenerCallback<T>

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::sync::Arc;
@@ -155,7 +155,7 @@ impl Drop for FlushJobInfo<'_> {
 }
 
 impl FlushJobInfo<'_> {
-    pub fn get_user_collected_property(&self, key: impl CStrLike) -> Option<CString> {
+    pub fn get_user_collected_property(&self, key: impl CStrLike) -> Option<&CStr> {
         unsafe {
             let key_cstring = key.into_c_string().unwrap();
             let value_ptr = ffi::rocksdb_table_properties_get_user_collected_property(
@@ -167,17 +167,18 @@ impl FlushJobInfo<'_> {
                 return None;
             }
 
-            let value_string = CStr::from_ptr(value_ptr).to_owned();
-            ffi::rocksdb_free(value_ptr as *mut c_void);
+            let value_string = CStr::from_ptr(value_ptr);
             Some(value_string)
         }
     }
 
-    pub fn get_user_collected_property_keys(&self) -> Vec<CString> {
+    pub fn get_user_collected_property_keys(&self, prefix: Option<impl CStrLike>) -> Vec<&CStr> {
         unsafe {
             let mut key_count: usize = 0;
+            let prefix = prefix.map_or_else(|| c"".to_owned(), |p| p.into_c_string().unwrap());
             let keys_ptr = ffi::rocksdb_table_properties_get_user_collected_property_keys(
                 self.table_properties.as_ptr(),
+                prefix.as_ptr(),
                 &mut key_count,
             );
 
@@ -189,8 +190,7 @@ impl FlushJobInfo<'_> {
             for i in 0..key_count {
                 let key_ptr = *keys_ptr.add(i);
                 if !key_ptr.is_null() {
-                    result.push(CStr::from_ptr(key_ptr).to_owned());
-                    ffi::rocksdb_free(key_ptr as *mut c_void);
+                    result.push(CStr::from_ptr(key_ptr));
                 }
             }
             ffi::rocksdb_free(keys_ptr as *mut c_void);

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -154,7 +154,7 @@ impl Drop for FlushJobInfo<'_> {
     }
 }
 
-impl<'a> FlushJobInfo<'a> {
+impl FlushJobInfo<'_> {
     pub fn get_user_collected_property(&self, key: impl CStrLike) -> Option<CString> {
         unsafe {
             let key_cstring = key.into_c_string().unwrap();
@@ -165,7 +165,7 @@ impl<'a> FlushJobInfo<'a> {
 
             if value_ptr.is_null() {
                 return None;
-            };
+            }
 
             let value_string = CStr::from_ptr(value_ptr).to_owned();
             ffi::rocksdb_free(value_ptr as *mut c_void);

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -21,7 +21,7 @@ use libc::c_void;
 
 use crate::ffi::rocksdb_flushjobinfo_t;
 use crate::ffi_util::from_cstr;
-use crate::{ffi, Options};
+use crate::{ffi, CStrLike, Options};
 
 /// EventListener defining a set of callbacks from RocksDB
 ///
@@ -155,9 +155,9 @@ impl Drop for FlushJobInfo<'_> {
 }
 
 impl<'a> FlushJobInfo<'a> {
-    pub fn get_user_collected_property(&self, key: &str) -> Option<CString> {
+    pub fn get_user_collected_property(&self, key: impl CStrLike) -> Option<CString> {
         unsafe {
-            let key_cstring = CString::new(key).unwrap();
+            let key_cstring = key.into_c_string().unwrap();
             let value_ptr = ffi::rocksdb_table_properties_get_user_collected_property(
                 self.table_properties.as_ptr(),
                 key_cstring.as_ptr(),

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -155,7 +155,7 @@ impl Drop for FlushJobInfo<'_> {
 }
 
 impl<'a> FlushJobInfo<'a> {
-    pub fn get_user_collected_property(&self, key: &str) -> Option<String> {
+    pub fn get_user_collected_property(&self, key: &str) -> Option<CString> {
         unsafe {
             let key_cstring = CString::new(key).unwrap();
             let value_ptr = ffi::rocksdb_table_properties_get_user_collected_property(
@@ -167,7 +167,7 @@ impl<'a> FlushJobInfo<'a> {
                 return None;
             };
 
-            let value_string = CStr::from_ptr(value_ptr).to_str().unwrap().to_owned();
+            let value_string = CStr::from_ptr(value_ptr).to_owned();
             ffi::rocksdb_free(value_ptr as *mut c_void);
             Some(value_string)
         }

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::ptr::NonNull;
 use std::sync::Arc;
 
 use libc::c_void;
@@ -94,8 +97,8 @@ impl EventListenerExt for Options {
                 Some(EventListenerCallback::<T>::on_flush_completed),
             );
 
-            // Takes ownership of the event listener, which will also drop the
-            // EventListenerCallback via the destructor callback
+            // Takes ownership of the event listener; the Rust callback wrapper will be
+            // dropped via the destructor callback
             ffi::rocksdb_options_add_event_listener(self.inner, event_listener_ptr);
         }
     }
@@ -103,7 +106,7 @@ impl EventListenerExt for Options {
 
 /// Flush information
 #[derive(Debug)]
-pub struct FlushJobInfo {
+pub struct FlushJobInfo<'a> {
     /// The name of the column family
     pub cf_name: String,
     /// The path to the newly created file
@@ -114,6 +117,12 @@ pub struct FlushJobInfo {
     pub largest_seqno: u64,
     /// Flush reason
     pub flush_reason: FlushReason,
+
+    // holds a pointer to data borrowed from RocksDB for the duration of the event handler callback;
+    // we are responsible for freeing the wrapper struct
+    table_properties: NonNull<ffi::rocksdb_table_properties_t>,
+
+    _marker: PhantomData<&'a ()>,
 }
 
 /// Flush reason
@@ -135,6 +144,34 @@ pub enum FlushReason {
     ErrorRecoveryRetryFlush = 12,
     WalFull = 13,
     CatchUpAfterErrorRecovery = 14,
+}
+
+impl Drop for FlushJobInfo<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_table_properties_destroy(self.table_properties.as_ptr());
+        }
+    }
+}
+
+impl<'a> FlushJobInfo<'a> {
+    pub fn get_user_collected_property(&self, key: &str) -> Option<String> {
+        unsafe {
+            let key_cstring = CString::new(key).unwrap();
+            let value_ptr = ffi::rocksdb_table_properties_get_user_collected_property(
+                self.table_properties.as_ptr(),
+                key_cstring.as_ptr(),
+            );
+
+            if value_ptr.is_null() {
+                return None;
+            };
+
+            let value_string = CStr::from_ptr(value_ptr).to_str().unwrap().to_owned();
+            ffi::rocksdb_free(value_ptr as *mut c_void);
+            Some(value_string)
+        }
+    }
 }
 
 pub(crate) struct EventListenerCallback<T>
@@ -180,12 +217,19 @@ where
             ffi::rocksdb_flushjobinfo_flushreason(flush_job_info),
         );
 
+        let table_properties = NonNull::new(unsafe {
+            ffi::rocksdb_flushjobinfo_table_properties(flush_job_info).cast_mut()
+        })
+        .unwrap();
+
         let flush_job_info = FlushJobInfo {
             cf_name,
             file_path,
             smallest_seqno,
             largest_seqno,
             flush_reason,
+            table_properties,
+            _marker: PhantomData,
         };
 
         let cb = &mut *(raw_cb as *mut Self);

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -172,10 +172,10 @@ impl FlushJobInfo<'_> {
         }
     }
 
-    pub fn get_user_collected_property_keys(&self, prefix: Option<impl CStrLike>) -> Vec<&CStr> {
+    pub fn get_user_collected_property_keys(&self, prefix: impl CStrLike) -> Vec<&CStr> {
         unsafe {
             let mut key_count: usize = 0;
-            let prefix = prefix.map_or_else(|| c"".to_owned(), |p| p.into_c_string().unwrap());
+            let prefix = prefix.into_c_string().unwrap();
             let keys_ptr = ffi::rocksdb_table_properties_get_user_collected_property_keys(
                 self.table_properties.as_ptr(),
                 prefix.as_ptr(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ mod slice_transform;
 mod snapshot;
 mod sst_file_writer;
 pub mod statistics;
+pub mod table_properties;
 mod transactions;
 mod write_batch;
 mod write_batch_with_index;

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -77,7 +77,7 @@ pub trait TablePropertiesCollector {
         entry_type: EntryType,
         seq: u64,
         file_size: u64,
-    ) -> Result<(), crate::Error>;
+    ) -> Result<(), ()>;
 
     /// Called after each new block is cut
     fn block_add(
@@ -92,7 +92,7 @@ pub trait TablePropertiesCollector {
     ///
     /// When the result is `Err`, the collected properties will not be written to the file's
     /// property block.
-    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, crate::Error>;
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, ()>;
 
     /// Returns human-readable properties used for logging
     ///

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -10,7 +10,7 @@ use crate::{ffi, Options};
 
 /// Extension trait for [`Options`] to register table properties collectors
 pub trait TablePropertiesExt {
-    fn add_table_properties_collector_factory<F>(&mut self, factory_fn: F)
+    fn add_table_properties_collector_factory<F>(&mut self, factory: F)
     where
         F: TablePropertiesCollectorFactory + Send + 'static;
 }
@@ -95,12 +95,12 @@ pub trait TablePropertiesCollector {
     ///
     /// When the returned Status is false, the collected properties will not be written to the
     /// file's property block.
-    fn finish(&mut self, properties: &mut HashMap<String, String>) -> bool;
+    fn finish(&mut self, properties: &mut HashMap<CString, CString>) -> bool;
 
     /// Returns human-readable properties used for logging
     ///
     /// It will only be called after finish() has been called.
-    fn get_readable_properties(&self) -> HashMap<String, String>;
+    fn get_readable_properties(&self) -> HashMap<CString, CString>;
 
     /// Name of the collector to use for logging
     fn name(&self) -> &CStr;
@@ -216,8 +216,6 @@ where
         collector.finish(&mut props);
 
         for (key, value) in &props {
-            let key = CString::new(key.as_str()).unwrap();
-            let value = CString::new(value.as_str()).unwrap();
             ffi::rocksdb_user_collected_properties_insert(
                 user_collected_properties,
                 key.as_ptr(),
@@ -236,8 +234,6 @@ where
         let props = collector.get_readable_properties();
 
         for (key, value) in &props {
-            let key = CString::new(key.as_str()).unwrap();
-            let value = CString::new(value.as_str()).unwrap();
             ffi::rocksdb_user_collected_properties_insert(
                 user_collected_properties,
                 key.as_ptr(),

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -70,6 +70,9 @@ pub trait TablePropertiesCollectorFactory {
 /// Table properties collector trait
 pub trait TablePropertiesCollector {
     /// Called when a new key/value pair is added to the table
+    ///
+    /// Returning `Err` will cause an error to be logged but otherwise continue building the
+    /// table as normal.
     fn add_user_key(
         &mut self,
         key: &[u8],
@@ -77,7 +80,7 @@ pub trait TablePropertiesCollector {
         entry_type: EntryType,
         seq: u64,
         file_size: u64,
-    ) -> Result<(), ()>;
+    ) -> Result<(), CollectorError>;
 
     /// Called after each new block is cut
     fn block_add(
@@ -92,7 +95,7 @@ pub trait TablePropertiesCollector {
     ///
     /// When the result is `Err`, the collected properties will not be written to the file's
     /// property block.
-    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, ()>;
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, CollectorError>;
 
     /// Returns human-readable properties used for logging
     ///
@@ -101,6 +104,21 @@ pub trait TablePropertiesCollector {
 
     /// Name of the collector to use for logging
     fn name(&self) -> &CStr;
+}
+
+/// Collector error
+///
+/// This error is not meaningfully used by RocksDB, other than to indicate an unsuccessful callback.
+/// It intentionally does not accept a message or other detail as these would be ignored downstream.
+#[derive(Debug, Default)]
+pub struct CollectorError {
+    _private: (),
+}
+
+impl std::fmt::Display for CollectorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Property collector error")
+    }
 }
 
 struct TablePropertiesCollectorFactoryCallback<F>

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -231,7 +231,7 @@ where
 
         let Ok(props) = collector.finish() else {
             // An error will be logged by RocksDB to its own log, though the details will be swallowed.
-            // Property collectors should perform their own logging via other mehanisms if required.
+            // Property collectors should perform their own logging via other mechanisms if required.
             return false;
         };
 

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_void, CStr};
+use std::ffi::{c_char, c_void, CStr, CString};
 use std::marker::PhantomData;
 use std::mem;
 use std::slice;
@@ -9,19 +9,15 @@ use crate::{ffi, Options};
 
 /// Extension trait for [`Options`] to register table properties collectors
 pub trait TablePropertiesExt {
-    fn add_table_properties_collector_factory<F, K, V>(&mut self, factory: F)
+    fn add_table_properties_collector_factory<F>(&mut self, factory: F)
     where
-        F: TablePropertiesCollectorFactory<K, V> + Send + 'static,
-        K: AsRef<CStr>,
-        V: AsRef<CStr>;
+        F: TablePropertiesCollectorFactory + Send + 'static;
 }
 
 impl TablePropertiesExt for Options {
-    fn add_table_properties_collector_factory<F, K, V>(&mut self, factory: F)
+    fn add_table_properties_collector_factory<F>(&mut self, factory: F)
     where
-        F: TablePropertiesCollectorFactory<K, V> + Send + 'static,
-        K: AsRef<CStr>,
-        V: AsRef<CStr>,
+        F: TablePropertiesCollectorFactory + Send + 'static,
     {
         unsafe {
             let factory_ptr = Box::into_raw(Box::new(factory)) as *mut c_void;
@@ -31,9 +27,9 @@ impl TablePropertiesExt for Options {
             ffi::rocksdb_options_add_table_properties_collector_factory(
                 self.inner,
                 factory_ptr,
-                Some(TablePropertiesCollectorFactoryCallback::<F, K, V>::destructor),
-                Some(TablePropertiesCollectorFactoryCallback::<F, K, V>::name),
-                Some(TablePropertiesCollectorFactoryCallback::<F, K, V>::create_collector),
+                Some(TablePropertiesCollectorFactoryCallback::<F>::destructor),
+                Some(TablePropertiesCollectorFactoryCallback::<F>::name),
+                Some(TablePropertiesCollectorFactoryCallback::<F>::create_collector),
             );
         }
     }
@@ -61,12 +57,8 @@ pub struct TablePropertiesCollectorContext {
 }
 
 /// Table properties collector factory trait
-pub trait TablePropertiesCollectorFactory<K, V>
-where
-    K: AsRef<CStr>,
-    V: AsRef<CStr>,
-{
-    type Collector: TablePropertiesCollector<K, V>;
+pub trait TablePropertiesCollectorFactory {
+    type Collector: TablePropertiesCollector;
 
     /// Create a new table properties collector
     fn create(&mut self, context: TablePropertiesCollectorContext) -> Self::Collector;
@@ -76,20 +68,8 @@ where
 }
 
 /// Table properties collector trait
-pub trait TablePropertiesCollector<K, V>
-where
-    K: AsRef<CStr>,
-    V: AsRef<CStr>,
-{
-    type PropertyIterator<'a>: IntoIterator<Item = &'a (K, V)>
-    where
-        Self: 'a,
-        K: 'a,
-        V: 'a;
-
+pub trait TablePropertiesCollector {
     /// Called when a new key/value pair is added to the table
-    ///
-    /// Return `true` when on success; returning `false` logs an error.
     fn add_user_key(
         &mut self,
         key: &[u8],
@@ -97,7 +77,7 @@ where
         entry_type: EntryType,
         seq: u64,
         file_size: u64,
-    ) -> bool;
+    ) -> Result<(), crate::Error>;
 
     /// Called after each new block is cut
     fn block_add(
@@ -112,31 +92,27 @@ where
     ///
     /// When the result is `Err`, the collected properties will not be written to the file's
     /// property block.
-    fn finish(&mut self) -> Result<Self::PropertyIterator<'_>, crate::Error>;
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, crate::Error>;
 
     /// Returns human-readable properties used for logging
     ///
     /// This method will be called after finish() has been called.
-    fn get_readable_properties(&self) -> Self::PropertyIterator<'_>;
+    fn get_readable_properties(&self) -> impl IntoIterator<Item = &(CString, CString)>;
 
     /// Name of the collector to use for logging
     fn name(&self) -> &CStr;
 }
 
-struct TablePropertiesCollectorFactoryCallback<F, K, V>
+struct TablePropertiesCollectorFactoryCallback<F>
 where
-    F: TablePropertiesCollectorFactory<K, V> + Send + 'static,
-    K: AsRef<CStr>,
-    V: AsRef<CStr>,
+    F: TablePropertiesCollectorFactory + Send + 'static,
 {
-    _phantom: PhantomData<(F, K, V)>,
+    _phantom: PhantomData<F>,
 }
 
-impl<F, K, V> TablePropertiesCollectorFactoryCallback<F, K, V>
+impl<F> TablePropertiesCollectorFactoryCallback<F>
 where
-    F: TablePropertiesCollectorFactory<K, V> + Send + 'static,
-    K: AsRef<CStr>,
-    V: AsRef<CStr>,
+    F: TablePropertiesCollectorFactory + Send + 'static,
 {
     unsafe extern "C" fn create_collector(
         raw_self: *mut c_void,
@@ -155,12 +131,12 @@ where
 
         ffi::rocksdb_table_properties_collector_create(
             Box::into_raw(collector).cast(),
-            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::destructor),
-            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::add_user_key),
-            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::block_add),
-            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::finish),
-            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::get_readable_properties),
-            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::name),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::destructor),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::add_user_key),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::block_add),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::finish),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::get_readable_properties),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::name),
         )
     }
 
@@ -174,20 +150,16 @@ where
     }
 }
 
-struct TablePropertiesCollectorCallback<C, K, V>
+struct TablePropertiesCollectorCallback<C>
 where
-    C: TablePropertiesCollector<K, V>,
-    K: AsRef<CStr>,
-    V: AsRef<CStr>,
+    C: TablePropertiesCollector,
 {
-    _marker: PhantomData<(C, K, V)>,
+    _marker: PhantomData<C>,
 }
 
-impl<C, K, V> TablePropertiesCollectorCallback<C, K, V>
+impl<C> TablePropertiesCollectorCallback<C>
 where
-    C: TablePropertiesCollector<K, V>,
-    K: AsRef<CStr>,
-    V: AsRef<CStr>,
+    C: TablePropertiesCollector,
 {
     unsafe extern "C" fn destructor(raw_collector: *mut c_void) {
         drop(Box::from_raw(raw_collector as *mut C));
@@ -214,7 +186,9 @@ where
         let value = slice::from_raw_parts(value_ptr as *const u8, value_len);
         let entry_type = mem::transmute::<c_int, EntryType>(entry_type);
 
-        collector.add_user_key(key, value, entry_type, seq, file_size)
+        collector
+            .add_user_key(key, value, entry_type, seq, file_size)
+            .is_ok()
     }
 
     unsafe extern "C" fn block_add(

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-use std::ffi::{c_char, c_void, CStr, CString};
+use std::ffi::{c_char, c_void, CStr};
 use std::marker::PhantomData;
 use std::mem;
 use std::slice;
@@ -10,15 +9,19 @@ use crate::{ffi, Options};
 
 /// Extension trait for [`Options`] to register table properties collectors
 pub trait TablePropertiesExt {
-    fn add_table_properties_collector_factory<F>(&mut self, factory: F)
+    fn add_table_properties_collector_factory<F, K, V>(&mut self, factory: F)
     where
-        F: TablePropertiesCollectorFactory + Send + 'static;
+        F: TablePropertiesCollectorFactory<K, V> + Send + 'static,
+        K: AsRef<CStr>,
+        V: AsRef<CStr>;
 }
 
 impl TablePropertiesExt for Options {
-    fn add_table_properties_collector_factory<F>(&mut self, factory: F)
+    fn add_table_properties_collector_factory<F, K, V>(&mut self, factory: F)
     where
-        F: TablePropertiesCollectorFactory + Send + 'static,
+        F: TablePropertiesCollectorFactory<K, V> + Send + 'static,
+        K: AsRef<CStr>,
+        V: AsRef<CStr>,
     {
         unsafe {
             let factory_ptr = Box::into_raw(Box::new(factory)) as *mut c_void;
@@ -28,9 +31,9 @@ impl TablePropertiesExt for Options {
             ffi::rocksdb_options_add_table_properties_collector_factory(
                 self.inner,
                 factory_ptr,
-                Some(TablePropertiesCollectorFactoryCallback::<F>::destructor),
-                Some(TablePropertiesCollectorFactoryCallback::<F>::name),
-                Some(TablePropertiesCollectorFactoryCallback::<F>::create_collector),
+                Some(TablePropertiesCollectorFactoryCallback::<F, K, V>::destructor),
+                Some(TablePropertiesCollectorFactoryCallback::<F, K, V>::name),
+                Some(TablePropertiesCollectorFactoryCallback::<F, K, V>::create_collector),
             );
         }
     }
@@ -58,8 +61,12 @@ pub struct TablePropertiesCollectorContext {
 }
 
 /// Table properties collector factory trait
-pub trait TablePropertiesCollectorFactory {
-    type Collector: TablePropertiesCollector;
+pub trait TablePropertiesCollectorFactory<K, V>
+where
+    K: AsRef<CStr>,
+    V: AsRef<CStr>,
+{
+    type Collector: TablePropertiesCollector<K, V>;
 
     /// Create a new table properties collector
     fn create(&mut self, context: TablePropertiesCollectorContext) -> Self::Collector;
@@ -69,7 +76,17 @@ pub trait TablePropertiesCollectorFactory {
 }
 
 /// Table properties collector trait
-pub trait TablePropertiesCollector {
+pub trait TablePropertiesCollector<K, V>
+where
+    K: AsRef<CStr>,
+    V: AsRef<CStr>,
+{
+    type PropertyIterator<'a>: IntoIterator<Item = &'a (K, V)>
+    where
+        Self: 'a,
+        K: 'a,
+        V: 'a;
+
     /// Called when a new key/value pair is added to the table
     ///
     /// Return `true` when on success; returning `false` logs an error.
@@ -93,29 +110,33 @@ pub trait TablePropertiesCollector {
 
     /// Called once when a table has been built and is ready for writing the properties block
     ///
-    /// When the returned Status is false, the collected properties will not be written to the
-    /// file's property block.
-    fn finish(&mut self, properties: &mut HashMap<CString, CString>) -> bool;
+    /// When the result is `Err`, the collected properties will not be written to the file's
+    /// property block.
+    fn finish(&mut self) -> Result<Self::PropertyIterator<'_>, crate::Error>;
 
     /// Returns human-readable properties used for logging
     ///
-    /// It will only be called after finish() has been called.
-    fn get_readable_properties(&self) -> HashMap<CString, CString>;
+    /// This method will be called after finish() has been called.
+    fn get_readable_properties(&self) -> Self::PropertyIterator<'_>;
 
     /// Name of the collector to use for logging
     fn name(&self) -> &CStr;
 }
 
-struct TablePropertiesCollectorFactoryCallback<F>
+struct TablePropertiesCollectorFactoryCallback<F, K, V>
 where
-    F: TablePropertiesCollectorFactory + Send + 'static,
+    F: TablePropertiesCollectorFactory<K, V> + Send + 'static,
+    K: AsRef<CStr>,
+    V: AsRef<CStr>,
 {
-    _phantom: PhantomData<F>,
+    _phantom: PhantomData<(F, K, V)>,
 }
 
-impl<F> TablePropertiesCollectorFactoryCallback<F>
+impl<F, K, V> TablePropertiesCollectorFactoryCallback<F, K, V>
 where
-    F: TablePropertiesCollectorFactory + Send + 'static,
+    F: TablePropertiesCollectorFactory<K, V> + Send + 'static,
+    K: AsRef<CStr>,
+    V: AsRef<CStr>,
 {
     unsafe extern "C" fn create_collector(
         raw_self: *mut c_void,
@@ -134,12 +155,12 @@ where
 
         ffi::rocksdb_table_properties_collector_create(
             Box::into_raw(collector).cast(),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::destructor),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::add_user_key),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::block_add),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::finish),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::get_readable_properties),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::name),
+            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::destructor),
+            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::add_user_key),
+            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::block_add),
+            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::finish),
+            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::get_readable_properties),
+            Some(TablePropertiesCollectorCallback::<F::Collector, K, V>::name),
         )
     }
 
@@ -153,16 +174,20 @@ where
     }
 }
 
-struct TablePropertiesCollectorCallback<C>
+struct TablePropertiesCollectorCallback<C, K, V>
 where
-    C: TablePropertiesCollector,
+    C: TablePropertiesCollector<K, V>,
+    K: AsRef<CStr>,
+    V: AsRef<CStr>,
 {
-    _marker: PhantomData<C>,
+    _marker: PhantomData<(C, K, V)>,
 }
 
-impl<C> TablePropertiesCollectorCallback<C>
+impl<C, K, V> TablePropertiesCollectorCallback<C, K, V>
 where
-    C: TablePropertiesCollector,
+    C: TablePropertiesCollector<K, V>,
+    K: AsRef<CStr>,
+    V: AsRef<CStr>,
 {
     unsafe extern "C" fn destructor(raw_collector: *mut c_void) {
         drop(Box::from_raw(raw_collector as *mut C));
@@ -212,14 +237,17 @@ where
     ) -> bool {
         let collector: &mut C = &mut *(raw_collector.cast());
 
-        let mut props = HashMap::new();
-        collector.finish(&mut props);
+        let Ok(props) = collector.finish() else {
+            // An error will be logged by RocksDB to its own log, though the details will be swallowed.
+            // Property collectors should perform their own logging via other mehanisms if required.
+            return false;
+        };
 
-        for (key, value) in &props {
+        for (key, value) in props {
             ffi::rocksdb_user_collected_properties_insert(
                 user_collected_properties,
-                key.as_ptr(),
-                value.as_ptr(),
+                key.as_ref().as_ptr(),
+                value.as_ref().as_ptr(),
             );
         }
 
@@ -233,11 +261,11 @@ where
         let collector: &mut C = &mut *(raw_collector.cast());
         let props = collector.get_readable_properties();
 
-        for (key, value) in &props {
+        for (key, value) in props {
             ffi::rocksdb_user_collected_properties_insert(
                 user_collected_properties,
-                key.as_ptr(),
-                value.as_ptr(),
+                key.as_ref().as_ptr(),
+                value.as_ref().as_ptr(),
             );
         }
     }

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -1,0 +1,248 @@
+use std::collections::HashMap;
+use std::ffi::{c_char, c_void, CStr, CString};
+use std::marker::PhantomData;
+use std::mem;
+use std::slice;
+
+use libc::{c_int, size_t};
+
+use crate::{ffi, Options};
+
+/// Extension trait for [`Options`] to register table properties collectors
+pub trait TablePropertiesExt {
+    fn add_table_properties_collector_factory<F>(&mut self, factory_fn: F)
+    where
+        F: TablePropertiesCollectorFactory + Send + 'static;
+}
+
+impl TablePropertiesExt for Options {
+    fn add_table_properties_collector_factory<F>(&mut self, factory: F)
+    where
+        F: TablePropertiesCollectorFactory + Send + 'static,
+    {
+        unsafe {
+            let factory_ptr = Box::into_raw(Box::new(factory)) as *mut c_void;
+
+            // Takes ownership of the collector factory; the Rust callback wrapper will be
+            // dropped via the destructor callback
+            ffi::rocksdb_options_add_table_properties_collector_factory(
+                self.inner,
+                factory_ptr,
+                Some(TablePropertiesCollectorFactoryCallback::<F>::destructor),
+                Some(TablePropertiesCollectorFactoryCallback::<F>::name),
+                Some(TablePropertiesCollectorFactoryCallback::<F>::create_collector),
+            );
+        }
+    }
+}
+
+#[repr(C)]
+pub enum EntryType {
+    EntryPut,
+    EntryDelete,
+    EntrySingleDelete,
+    EntryMerge,
+    EntryRangeDeletion,
+    EntryBlobIndex,
+    EntryDeleteWithTimestamp,
+    EntryWideColumnEntity,
+    EntryTimedPut,
+    EntryOther,
+}
+
+pub struct TablePropertiesCollectorContext {
+    pub column_family_id: u32,
+    pub level_at_creation: i32,
+    pub num_levels: i32,
+    pub last_level_inclusive_max_seqno_threshold: u64,
+}
+
+/// Table properties collector factory trait
+pub trait TablePropertiesCollectorFactory {
+    type Collector: TablePropertiesCollector;
+
+    /// Create a new table properties collector
+    fn create(&mut self, context: TablePropertiesCollectorContext) -> Self::Collector;
+
+    /// Name of the collector factory to use for logging
+    fn name(&self) -> &CStr;
+}
+
+/// Table properties collector trait
+pub trait TablePropertiesCollector {
+    /// Called when a new key/value pair is added to the table
+    ///
+    /// Return `true` when on success; returning `false` logs an error.
+    fn add_user_key(
+        &mut self,
+        key: &[u8],
+        value: &[u8],
+        entry_type: EntryType,
+        seq: u64,
+        file_size: u64,
+    ) -> bool;
+
+    /// Called after each new block is cut
+    fn block_add(
+        &mut self,
+        _block_uncompressed_bytes: u64,
+        _block_compressed_bytes_fast: u64,
+        _block_compressed_bytes_slow: u64,
+    ) {
+    }
+
+    /// Called once when a table has been built and is ready for writing the properties block
+    ///
+    /// When the returned Status is false, the collected properties will not be written to the
+    /// file's property block.
+    fn finish(&mut self, properties: &mut HashMap<String, String>) -> bool;
+
+    /// Returns human-readable properties used for logging
+    ///
+    /// It will only be called after finish() has been called.
+    fn get_readable_properties(&self) -> HashMap<String, String>;
+
+    /// Name of the collector to use for logging
+    fn name(&self) -> &CStr;
+}
+
+struct TablePropertiesCollectorFactoryCallback<F>
+where
+    F: TablePropertiesCollectorFactory + Send + 'static,
+{
+    _phantom: PhantomData<F>,
+}
+
+impl<F> TablePropertiesCollectorFactoryCallback<F>
+where
+    F: TablePropertiesCollectorFactory + Send + 'static,
+{
+    unsafe extern "C" fn create_collector(
+        raw_self: *mut c_void,
+        ctx: *mut ffi::rocksdb_table_properties_collector_context_t,
+    ) -> *mut ffi::rocksdb_table_properties_collector_t {
+        let context = TablePropertiesCollectorContext {
+                column_family_id: ffi::rocksdb_table_properties_collector_context_get_column_family_id(ctx),
+                level_at_creation: ffi::rocksdb_table_properties_collector_context_get_level_at_creation(ctx),
+                num_levels: ffi::rocksdb_table_properties_collector_context_get_num_levels(ctx),
+                last_level_inclusive_max_seqno_threshold:
+                    ffi::rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_threshold(ctx),
+            };
+
+        let factory: &mut F = &mut *(raw_self.cast());
+        let collector = Box::new(factory.create(context));
+
+        ffi::rocksdb_table_properties_collector_create(
+            Box::into_raw(collector).cast(),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::destructor),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::add_user_key),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::block_add),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::finish),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::get_readable_properties),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::name),
+        )
+    }
+
+    unsafe extern "C" fn name(raw_self: *mut c_void) -> *const c_char {
+        let factory = &*(raw_self.cast_const() as *const F);
+        factory.name().as_ptr()
+    }
+
+    unsafe extern "C" fn destructor(raw_self: *mut c_void) {
+        drop(Box::from_raw(raw_self as *mut F));
+    }
+}
+
+struct TablePropertiesCollectorCallback<C>
+where
+    C: TablePropertiesCollector,
+{
+    _marker: PhantomData<C>,
+}
+
+impl<C> TablePropertiesCollectorCallback<C>
+where
+    C: TablePropertiesCollector,
+{
+    unsafe extern "C" fn destructor(raw_collector: *mut c_void) {
+        drop(Box::from_raw(raw_collector as *mut C));
+    }
+
+    unsafe extern "C" fn name(raw_collector: *mut c_void) -> *const c_char {
+        let collector: &mut C = &mut *(raw_collector.cast());
+        collector.name().as_ptr()
+    }
+
+    unsafe extern "C" fn add_user_key(
+        raw_collector: *mut c_void,
+        key_ptr: *const c_char,
+        key_len: size_t,
+        value_ptr: *const c_char,
+        value_len: size_t,
+        entry_type: c_int,
+        seq: u64,
+        file_size: u64,
+    ) -> bool {
+        let collector: &mut C = &mut *(raw_collector.cast());
+
+        let key = slice::from_raw_parts(key_ptr as *const u8, key_len);
+        let value = slice::from_raw_parts(value_ptr as *const u8, value_len);
+        let entry_type = mem::transmute::<c_int, EntryType>(entry_type);
+
+        collector.add_user_key(key, value, entry_type, seq, file_size)
+    }
+
+    unsafe extern "C" fn block_add(
+        raw_collector: *mut c_void,
+        block_uncompressed_bytes: u64,
+        block_compressed_bytes_fast: u64,
+        block_compressed_bytes_slow: u64,
+    ) {
+        let collector: &mut C = &mut *(raw_collector.cast());
+        collector.block_add(
+            block_uncompressed_bytes,
+            block_compressed_bytes_fast,
+            block_compressed_bytes_slow,
+        );
+    }
+
+    unsafe extern "C" fn finish(
+        raw_collector: *mut c_void,
+        user_collected_properties: *mut ffi::rocksdb_user_collected_properties_t,
+    ) -> bool {
+        let collector: &mut C = &mut *(raw_collector.cast());
+
+        let mut props = HashMap::new();
+        collector.finish(&mut props);
+
+        for (key, value) in &props {
+            let key = CString::new(key.as_str()).unwrap();
+            let value = CString::new(value.as_str()).unwrap();
+            ffi::rocksdb_user_collected_properties_insert(
+                user_collected_properties,
+                key.as_ptr(),
+                value.as_ptr(),
+            );
+        }
+
+        true
+    }
+
+    unsafe extern "C" fn get_readable_properties(
+        raw_collector: *mut c_void,
+        user_collected_properties: *mut ffi::rocksdb_user_collected_properties_t,
+    ) {
+        let collector: &mut C = &mut *(raw_collector.cast());
+        let props = collector.get_readable_properties();
+
+        for (key, value) in &props {
+            let key = CString::new(key.as_str()).unwrap();
+            let value = CString::new(value.as_str()).unwrap();
+            ffi::rocksdb_user_collected_properties_insert(
+                user_collected_properties,
+                key.as_ptr(),
+                value.as_ptr(),
+            );
+        }
+    }
+}

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -1,7 +1,6 @@
 mod util;
 
 use std::ffi::{CStr, CString};
-use std::slice;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -75,7 +74,7 @@ fn test_table_properties_collector() {
 
 struct KeyStartsWithACollectorFactory(CString);
 
-impl TablePropertiesCollectorFactory<CString, CString> for KeyStartsWithACollectorFactory {
+impl TablePropertiesCollectorFactory for KeyStartsWithACollectorFactory {
     type Collector = KeyStartsWithACollector;
 
     fn create(&mut self, _context: TablePropertiesCollectorContext) -> Self::Collector {
@@ -96,9 +95,7 @@ struct KeyStartsWithACollector {
     props: Vec<(CString, CString)>,
 }
 
-impl TablePropertiesCollector<CString, CString> for KeyStartsWithACollector {
-    type PropertyIterator<'a> = slice::Iter<'a, (CString, CString)>;
-
+impl TablePropertiesCollector for KeyStartsWithACollector {
     fn add_user_key(
         &mut self,
         key: &[u8],
@@ -106,16 +103,18 @@ impl TablePropertiesCollector<CString, CString> for KeyStartsWithACollector {
         entry_type: EntryType,
         _seq: u64,
         _file_size: u64,
-    ) -> bool {
+    ) -> Result<(), rust_rocksdb::Error> {
         if let EntryType::EntryPut = entry_type {
             if key.starts_with(b"a") || key.starts_with(b"A") {
                 self.count += 1;
             }
         }
-        true
+        Ok(())
     }
 
-    fn finish(&mut self) -> Result<slice::Iter<'_, (CString, CString)>, rust_rocksdb::Error> {
+    fn finish(
+        &mut self,
+    ) -> Result<impl IntoIterator<Item = &(CString, CString)>, rust_rocksdb::Error> {
         self.props.push((
             c"key_count".to_owned(),
             CString::new(self.count.to_string()).unwrap(),
@@ -124,7 +123,7 @@ impl TablePropertiesCollector<CString, CString> for KeyStartsWithACollector {
         Ok(self.props.iter())
     }
 
-    fn get_readable_properties(&self) -> slice::Iter<'_, (CString, CString)> {
+    fn get_readable_properties(&self) -> impl IntoIterator<Item = &(CString, CString)> {
         self.props.iter()
     }
 

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -22,7 +22,7 @@ fn test_table_properties_collector() {
     opts.create_if_missing(true);
     opts.create_missing_column_families(true);
 
-    // Contrary to what the docs say, event listeners are DB-level, and can't be set at the CF level
+    // Event listeners are DB-wide
     let listener = Arc::new(CustomPropertyListener {
         state: RwLock::new(ObservedProperties::default()),
     });
@@ -44,6 +44,7 @@ fn test_table_properties_collector() {
     db.put_cf(&cf, b"a", b"foo").unwrap();
     assert_eq!(0, listener.state.read().flush_count);
     assert_eq!(None, listener.state.read().latest_persisted_key_count);
+    assert_eq!(None, listener.state.read().all_keys);
 
     db.flush_cf(&cf).unwrap();
     assert_eq!(1, listener.state.read().flush_count);
@@ -51,6 +52,8 @@ fn test_table_properties_collector() {
         Some(c"1".to_owned()),
         listener.state.read().latest_persisted_key_count
     );
+    let all_user_keys = listener.state.read().all_keys.clone().unwrap();
+    assert!(all_user_keys.contains(&c"key_count".to_owned()));
 
     db.put_cf(&cf, b"aaa", b"foo").unwrap();
     db.put_cf(&cf, b"bbb", b"bar").unwrap();
@@ -170,6 +173,7 @@ struct CustomPropertyListener {
 struct ObservedProperties {
     flush_count: u32,
     latest_persisted_key_count: Option<CString>,
+    all_keys: Option<Vec<CString>>,
 }
 
 impl EventListener for CustomPropertyListener {
@@ -177,5 +181,6 @@ impl EventListener for CustomPropertyListener {
         let mut guard = self.state.write();
         guard.flush_count += 1;
         guard.latest_persisted_key_count = info.get_user_collected_property("key_count");
+        guard.all_keys = Some(info.get_user_collected_property_keys());
     }
 }

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -180,7 +180,14 @@ impl EventListener for CustomPropertyListener {
     fn on_flush_completed(&self, info: FlushJobInfo) {
         let mut guard = self.state.write();
         guard.flush_count += 1;
-        guard.latest_persisted_key_count = info.get_user_collected_property("key_count");
-        guard.all_keys = Some(info.get_user_collected_property_keys());
+        guard.latest_persisted_key_count = info
+            .get_user_collected_property("key_count")
+            .map(|cstr| cstr.to_owned());
+        guard.all_keys = Some(
+            info.get_user_collected_property_keys(Some(c"key_"))
+                .iter()
+                .map(|&cstr| cstr.to_owned())
+                .collect(),
+        );
     }
 }

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -1,0 +1,146 @@
+mod util;
+
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use rust_rocksdb::event_listener::{EventListener, EventListenerExt, FlushJobInfo};
+use rust_rocksdb::table_properties::{
+    EntryType, TablePropertiesCollector, TablePropertiesCollectorContext,
+    TablePropertiesCollectorFactory, TablePropertiesExt,
+};
+use rust_rocksdb::{Options, DB};
+use util::DBPath;
+
+#[test]
+fn test_table_properties_collector() {
+    let path = DBPath::new("_rust_rocksdb_properties_collector_test");
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+
+    // Contrary to what the docs say, event listeners are DB-level, and can't be set at the CF level
+    let listener = Arc::new(CustomPropertyListener {
+        state: RwLock::new(ObservedProperties::default()),
+    });
+    opts.add_event_listener(listener.clone());
+
+    let mut cf_opts = Options::default();
+    cf_opts.add_table_properties_collector_factory(KeyStartsWithACollectorFactory(
+        CString::new("AKeyCounterFactory").unwrap(),
+    ));
+
+    let db = DB::open_cf_with_opts(&opts, &path, [("cf", cf_opts)]).unwrap();
+
+    let cf = db.cf_handle("cf").unwrap();
+    db.put_cf(&cf, b"a", b"foo").unwrap();
+    assert_eq!(0, listener.state.read().flush_count);
+    assert_eq!(None, listener.state.read().latest_custom_property_value);
+
+    db.flush_cf(&cf).unwrap();
+    assert_eq!(1, listener.state.read().flush_count);
+    assert_eq!(
+        Some("1".to_owned()),
+        listener.state.read().latest_custom_property_value
+    );
+
+    db.put_cf(&cf, b"aaa", b"foo").unwrap();
+    db.put_cf(&cf, b"bbb", b"bar").unwrap();
+    db.put_cf(&cf, b"AAA", b"baz").unwrap();
+
+    assert_eq!(1, listener.state.read().flush_count);
+    assert_eq!(
+        Some("1".to_owned()),
+        listener.state.read().latest_custom_property_value
+    );
+
+    db.flush_cf(&cf).unwrap();
+    assert_eq!(2, listener.state.read().flush_count);
+    assert_eq!(
+        Some("2".to_owned()),
+        listener.state.read().latest_custom_property_value
+    );
+
+    db.put_cf(&cf, b"c", b"").unwrap();
+    db.flush_cf(&cf).unwrap();
+    assert_eq!(3, listener.state.read().flush_count);
+    assert_eq!(
+        Some("0".to_owned()),
+        listener.state.read().latest_custom_property_value
+    );
+}
+
+struct KeyStartsWithACollectorFactory(CString);
+
+impl TablePropertiesCollectorFactory for KeyStartsWithACollectorFactory {
+    type Collector = KeyStartsWithACollector;
+
+    fn create(&mut self, _context: TablePropertiesCollectorContext) -> Self::Collector {
+        KeyStartsWithACollector {
+            name: CString::new("AKeyCounter").unwrap(),
+            count: 0,
+        }
+    }
+
+    fn name(&self) -> &CStr {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+struct KeyStartsWithACollector {
+    name: CString,
+    count: usize,
+}
+
+impl TablePropertiesCollector for KeyStartsWithACollector {
+    fn add_user_key(
+        &mut self,
+        key: &[u8],
+        _value: &[u8],
+        entry_type: EntryType,
+        _seq: u64,
+        _file_size: u64,
+    ) -> bool {
+        if let EntryType::EntryPut = entry_type {
+            if key.starts_with(b"a") || key.starts_with(b"A") {
+                self.count += 1;
+            }
+        }
+        true
+    }
+
+    fn finish(&mut self, properties: &mut HashMap<String, String>) -> bool {
+        properties.insert("key_count".to_owned(), self.count.to_string());
+        true
+    }
+
+    fn get_readable_properties(&self) -> HashMap<String, String> {
+        HashMap::new()
+    }
+
+    fn name(&self) -> &CStr {
+        &self.name
+    }
+}
+
+struct CustomPropertyListener {
+    state: RwLock<ObservedProperties>,
+}
+
+#[derive(Default)]
+struct ObservedProperties {
+    flush_count: u32,
+    latest_custom_property_value: Option<String>,
+}
+
+impl EventListener for CustomPropertyListener {
+    fn on_flush_completed(&self, info: FlushJobInfo) {
+        let mut guard = self.state.write();
+        guard.flush_count += 1;
+        guard.latest_custom_property_value = info.get_user_collected_property("key_count");
+    }
+}

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -1,7 +1,7 @@
 mod util;
 
-use std::collections::HashMap;
 use std::ffi::{CStr, CString};
+use std::slice;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -75,11 +75,14 @@ fn test_table_properties_collector() {
 
 struct KeyStartsWithACollectorFactory(CString);
 
-impl TablePropertiesCollectorFactory for KeyStartsWithACollectorFactory {
+impl TablePropertiesCollectorFactory<CString, CString> for KeyStartsWithACollectorFactory {
     type Collector = KeyStartsWithACollector;
 
     fn create(&mut self, _context: TablePropertiesCollectorContext) -> Self::Collector {
-        KeyStartsWithACollector { count: 0 }
+        KeyStartsWithACollector {
+            count: 0,
+            props: vec![],
+        }
     }
 
     fn name(&self) -> &CStr {
@@ -90,9 +93,12 @@ impl TablePropertiesCollectorFactory for KeyStartsWithACollectorFactory {
 #[derive(Debug)]
 struct KeyStartsWithACollector {
     count: usize,
+    props: Vec<(CString, CString)>,
 }
 
-impl TablePropertiesCollector for KeyStartsWithACollector {
+impl TablePropertiesCollector<CString, CString> for KeyStartsWithACollector {
+    type PropertyIterator<'a> = slice::Iter<'a, (CString, CString)>;
+
     fn add_user_key(
         &mut self,
         key: &[u8],
@@ -109,16 +115,17 @@ impl TablePropertiesCollector for KeyStartsWithACollector {
         true
     }
 
-    fn finish(&mut self, properties: &mut HashMap<CString, CString>) -> bool {
-        properties.insert(
+    fn finish(&mut self) -> Result<slice::Iter<'_, (CString, CString)>, rust_rocksdb::Error> {
+        self.props.push((
             c"key_count".to_owned(),
-            CString::new(format!("{}", self.count)).unwrap(),
-        );
-        true
+            CString::new(self.count.to_string()).unwrap(),
+        ));
+
+        Ok(self.props.iter())
     }
 
-    fn get_readable_properties(&self) -> HashMap<CString, CString> {
-        HashMap::new()
+    fn get_readable_properties(&self) -> slice::Iter<'_, (CString, CString)> {
+        self.props.iter()
     }
 
     fn name(&self) -> &CStr {

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -1,13 +1,14 @@
 mod util;
 
 use std::ffi::{CStr, CString};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
 
 use rust_rocksdb::event_listener::{EventListener, EventListenerExt, FlushJobInfo};
 use rust_rocksdb::table_properties::{
-    EntryType, TablePropertiesCollector, TablePropertiesCollectorContext,
+    CollectorError, EntryType, TablePropertiesCollector, TablePropertiesCollectorContext,
     TablePropertiesCollectorFactory, TablePropertiesExt,
 };
 use rust_rocksdb::{Options, DB};
@@ -28,22 +29,27 @@ fn test_table_properties_collector() {
     opts.add_event_listener(listener.clone());
 
     let mut cf_opts = Options::default();
-    cf_opts.add_table_properties_collector_factory(KeyStartsWithACollectorFactory(
-        c"AKeyCounterFactory".to_owned(),
-    ));
+    let match_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    let collector_factory = KeyStartsWithACollectorFactory {
+        name: c"AKeyCounterFactory".to_owned(),
+        match_count: Arc::clone(&match_count),
+        error_count: Arc::clone(&error_count),
+    };
+    cf_opts.add_table_properties_collector_factory(collector_factory);
 
     let db = DB::open_cf_with_opts(&opts, &path, [("cf", cf_opts)]).unwrap();
 
     let cf = db.cf_handle("cf").unwrap();
     db.put_cf(&cf, b"a", b"foo").unwrap();
     assert_eq!(0, listener.state.read().flush_count);
-    assert_eq!(None, listener.state.read().latest_custom_property_value);
+    assert_eq!(None, listener.state.read().latest_persisted_key_count);
 
     db.flush_cf(&cf).unwrap();
     assert_eq!(1, listener.state.read().flush_count);
     assert_eq!(
         Some(c"1".to_owned()),
-        listener.state.read().latest_custom_property_value
+        listener.state.read().latest_persisted_key_count
     );
 
     db.put_cf(&cf, b"aaa", b"foo").unwrap();
@@ -53,46 +59,62 @@ fn test_table_properties_collector() {
     assert_eq!(1, listener.state.read().flush_count);
     assert_eq!(
         Some(c"1".to_owned()),
-        listener.state.read().latest_custom_property_value
+        listener.state.read().latest_persisted_key_count
     );
 
     db.flush_cf(&cf).unwrap();
     assert_eq!(2, listener.state.read().flush_count);
     assert_eq!(
-        Some(c"2".to_owned()),
-        listener.state.read().latest_custom_property_value
+        Some(c"3".to_owned()),
+        listener.state.read().latest_persisted_key_count
     );
 
     db.put_cf(&cf, b"c", b"").unwrap();
     db.flush_cf(&cf).unwrap();
     assert_eq!(3, listener.state.read().flush_count);
     assert_eq!(
-        Some(c"0".to_owned()),
-        listener.state.read().latest_custom_property_value
+        Some(c"3".to_owned()),
+        listener.state.read().latest_persisted_key_count
     );
+
+    // Returning an error from the collector
+    assert_eq!(0, error_count.load(Ordering::Relaxed));
+    db.put_cf(&cf, b"error", b"test").unwrap();
+    db.flush_cf(&cf).unwrap();
+    assert_eq!(4, listener.state.read().flush_count);
+    assert_eq!(None, listener.state.read().latest_persisted_key_count);
+    assert_eq!(1, error_count.load(Ordering::Relaxed));
 }
 
-struct KeyStartsWithACollectorFactory(CString);
+struct KeyStartsWithACollectorFactory {
+    name: CString,
+    match_count: Arc<AtomicU32>,
+    error_count: Arc<AtomicU32>,
+}
 
 impl TablePropertiesCollectorFactory for KeyStartsWithACollectorFactory {
     type Collector = KeyStartsWithACollector;
 
     fn create(&mut self, _context: TablePropertiesCollectorContext) -> Self::Collector {
         KeyStartsWithACollector {
-            count: 0,
+            match_count: Arc::clone(&self.match_count),
+            error_count: Arc::clone(&self.error_count),
+            encountered_error: false,
             props: vec![],
         }
     }
 
     fn name(&self) -> &CStr {
-        &self.0
+        &self.name
     }
 }
 
 #[derive(Debug)]
 struct KeyStartsWithACollector {
-    count: usize,
+    match_count: Arc<AtomicU32>,
+    error_count: Arc<AtomicU32>,
     props: Vec<(CString, CString)>,
+    encountered_error: bool,
 }
 
 impl TablePropertiesCollector for KeyStartsWithACollector {
@@ -103,19 +125,29 @@ impl TablePropertiesCollector for KeyStartsWithACollector {
         entry_type: EntryType,
         _seq: u64,
         _file_size: u64,
-    ) -> Result<(), ()> {
+    ) -> Result<(), CollectorError> {
         if let EntryType::EntryPut = entry_type {
+            if key.starts_with(b"err") {
+                self.error_count.fetch_add(1, Ordering::Relaxed);
+                self.encountered_error = true;
+                return Err(CollectorError::default());
+            }
+
             if key.starts_with(b"a") || key.starts_with(b"A") {
-                self.count += 1;
+                self.match_count.fetch_add(1, Ordering::Relaxed);
             }
         }
         Ok(())
     }
 
-    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, ()> {
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, CollectorError> {
+        if self.encountered_error {
+            return Err(CollectorError::default());
+        }
+
         self.props.push((
             c"key_count".to_owned(),
-            CString::new(self.count.to_string()).unwrap(),
+            CString::new(self.match_count.load(Ordering::Relaxed).to_string()).unwrap(),
         ));
 
         Ok(self.props.iter())
@@ -137,13 +169,13 @@ struct CustomPropertyListener {
 #[derive(Default)]
 struct ObservedProperties {
     flush_count: u32,
-    latest_custom_property_value: Option<CString>,
+    latest_persisted_key_count: Option<CString>,
 }
 
 impl EventListener for CustomPropertyListener {
     fn on_flush_completed(&self, info: FlushJobInfo) {
         let mut guard = self.state.write();
         guard.flush_count += 1;
-        guard.latest_custom_property_value = info.get_user_collected_property("key_count");
+        guard.latest_persisted_key_count = info.get_user_collected_property("key_count");
     }
 }

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -30,7 +30,7 @@ fn test_table_properties_collector() {
 
     let mut cf_opts = Options::default();
     cf_opts.add_table_properties_collector_factory(KeyStartsWithACollectorFactory(
-        CString::new("AKeyCounterFactory").unwrap(),
+        c"AKeyCounterFactory".to_owned(),
     ));
 
     let db = DB::open_cf_with_opts(&opts, &path, [("cf", cf_opts)]).unwrap();
@@ -43,7 +43,7 @@ fn test_table_properties_collector() {
     db.flush_cf(&cf).unwrap();
     assert_eq!(1, listener.state.read().flush_count);
     assert_eq!(
-        Some("1".to_owned()),
+        Some(c"1".to_owned()),
         listener.state.read().latest_custom_property_value
     );
 
@@ -53,14 +53,14 @@ fn test_table_properties_collector() {
 
     assert_eq!(1, listener.state.read().flush_count);
     assert_eq!(
-        Some("1".to_owned()),
+        Some(c"1".to_owned()),
         listener.state.read().latest_custom_property_value
     );
 
     db.flush_cf(&cf).unwrap();
     assert_eq!(2, listener.state.read().flush_count);
     assert_eq!(
-        Some("2".to_owned()),
+        Some(c"2".to_owned()),
         listener.state.read().latest_custom_property_value
     );
 
@@ -68,7 +68,7 @@ fn test_table_properties_collector() {
     db.flush_cf(&cf).unwrap();
     assert_eq!(3, listener.state.read().flush_count);
     assert_eq!(
-        Some("0".to_owned()),
+        Some(c"0".to_owned()),
         listener.state.read().latest_custom_property_value
     );
 }
@@ -79,10 +79,7 @@ impl TablePropertiesCollectorFactory for KeyStartsWithACollectorFactory {
     type Collector = KeyStartsWithACollector;
 
     fn create(&mut self, _context: TablePropertiesCollectorContext) -> Self::Collector {
-        KeyStartsWithACollector {
-            name: CString::new("AKeyCounter").unwrap(),
-            count: 0,
-        }
+        KeyStartsWithACollector { count: 0 }
     }
 
     fn name(&self) -> &CStr {
@@ -92,7 +89,6 @@ impl TablePropertiesCollectorFactory for KeyStartsWithACollectorFactory {
 
 #[derive(Debug)]
 struct KeyStartsWithACollector {
-    name: CString,
     count: usize,
 }
 
@@ -113,17 +109,20 @@ impl TablePropertiesCollector for KeyStartsWithACollector {
         true
     }
 
-    fn finish(&mut self, properties: &mut HashMap<String, String>) -> bool {
-        properties.insert("key_count".to_owned(), self.count.to_string());
+    fn finish(&mut self, properties: &mut HashMap<CString, CString>) -> bool {
+        properties.insert(
+            c"key_count".to_owned(),
+            CString::new(format!("{}", self.count)).unwrap(),
+        );
         true
     }
 
-    fn get_readable_properties(&self) -> HashMap<String, String> {
+    fn get_readable_properties(&self) -> HashMap<CString, CString> {
         HashMap::new()
     }
 
     fn name(&self) -> &CStr {
-        &self.name
+        c"AKeyCounter"
     }
 }
 
@@ -134,7 +133,7 @@ struct CustomPropertyListener {
 #[derive(Default)]
 struct ObservedProperties {
     flush_count: u32,
-    latest_custom_property_value: Option<String>,
+    latest_custom_property_value: Option<CString>,
 }
 
 impl EventListener for CustomPropertyListener {

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -103,7 +103,7 @@ impl TablePropertiesCollector for KeyStartsWithACollector {
         entry_type: EntryType,
         _seq: u64,
         _file_size: u64,
-    ) -> Result<(), rust_rocksdb::Error> {
+    ) -> Result<(), ()> {
         if let EntryType::EntryPut = entry_type {
             if key.starts_with(b"a") || key.starts_with(b"A") {
                 self.count += 1;
@@ -112,9 +112,7 @@ impl TablePropertiesCollector for KeyStartsWithACollector {
         Ok(())
     }
 
-    fn finish(
-        &mut self,
-    ) -> Result<impl IntoIterator<Item = &(CString, CString)>, rust_rocksdb::Error> {
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, ()> {
         self.props.push((
             c"key_count".to_owned(),
             CString::new(self.count.to_string()).unwrap(),

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -184,7 +184,7 @@ impl EventListener for CustomPropertyListener {
             .get_user_collected_property("key_count")
             .map(|cstr| cstr.to_owned());
         guard.all_keys = Some(
-            info.get_user_collected_property_keys(Some(c"key_"))
+            info.get_user_collected_property_keys(c"key_")
                 .iter()
                 .map(|&cstr| cstr.to_owned())
                 .collect(),


### PR DESCRIPTION
Stack:

- #8
- __->__ #9 ([relevant commits only](https://github.com/restatedev/rust-rocksdb/pull/9/files/116663b9243431f8b5b70db794baa30657d5153e..4c4e1114541fd4bcf40f30cf2b482bb94d93d9be))

Depends on: https://github.com/restatedev/rocksdb/pull/8

---

Additional testing:

```
pavel@ubuntu:/Users/pavel/restate/rust-rocksdb$ cargo valgrind nextest run --no-capture event_listener table_properties
   Compiling rust-librocksdb-sys v0.36.0+10.1.3 (/Users/pavel/restate/rust-rocksdb/librocksdb-sys)
   Compiling rust-rocksdb v0.40.0-restate.1 (/Users/pavel/restate/rust-rocksdb)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 09s
info: using target runner `/home/pavel/.cargo/bin/cargo-valgrind` defined by environment variable `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER`(test), rust_rocksdb(test), test_write_────────────
 Nextest run ID 68c1ec12-c06b-422c-86b9-f18d8c07dc67 with nextest profile: default
    Starting 2 tests across 25 binaries (195 tests skipped)
       START             rust-rocksdb::test_event_listener test_event_listener

running 1 test
test test_event_listener ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.69s

        PASS [   3.348s] rust-rocksdb::test_event_listener test_event_listener
       START             rust-rocksdb::test_table_properties test_table_properties_collector

running 1 test
test test_table_properties_collector ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.70s

        PASS [   3.207s] rust-rocksdb::test_table_properties test_table_properties_collector
────────────
     Summary [   6.556s] 2 tests run: 2 passed, 195 skipped
```