### PR TITLE
Adds support for vectored put/merge operations in WriteBatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.43.0"
+version = "0.43.1"
 edition = "2021"
 rust-version = "1.81.0"
 authors = [
@@ -44,6 +44,7 @@ rust-librocksdb-sys = { path = "librocksdb-sys", version = "0.39.0", default-fea
     "static",
 ] }
 serde = { version = "1", features = ["derive"], optional = true }
+smallvec = { version = "1" }
 parking_lot = { version = "0.12" }
 smartstring = { version = "1.0" }
 

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -14,6 +14,8 @@
 
 use crate::{ffi, AsColumnFamilyRef};
 use libc::{c_char, c_void, size_t};
+use smallvec::SmallVec;
+use std::io::IoSlice;
 use std::slice;
 
 /// A type alias to keep compatibility. See [`WriteBatchWithTransaction`] for details
@@ -293,6 +295,62 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
         }
     }
 
+    /// Insert a value into the database using vectored I/O from multiple memory segments.
+    /// Avoids user-side copying when data spans multiple slices, though RocksDB still copies internally.
+    pub fn put_vectored(&mut self, key: &[IoSlice<'_>], value: &[IoSlice<'_>]) {
+        const INLINE: usize = 16;
+        let key_ptrs: SmallVec<[*const c_char; INLINE]> =
+            key.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let key_lens: SmallVec<[size_t; INLINE]> = key.iter().map(|s| s.len()).collect();
+
+        let value_ptrs: SmallVec<[*const c_char; INLINE]> =
+            value.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let value_lens: SmallVec<[size_t; INLINE]> = value.iter().map(|s| s.len()).collect();
+
+        unsafe {
+            ffi::rocksdb_writebatch_putv(
+                self.inner,
+                key.len() as libc::c_int,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                value.len() as libc::c_int,
+                value_ptrs.as_ptr(),
+                value_lens.as_ptr(),
+            );
+        }
+    }
+
+    /// Insert a value into a column family using vectored I/O from multiple memory segments.
+    /// Avoids user-side copying when data spans multiple slices, though RocksDB still copies internally.
+    pub fn put_cf_vectored(
+        &mut self,
+        cf: &impl AsColumnFamilyRef,
+        key: &[IoSlice<'_>],
+        value: &[IoSlice<'_>],
+    ) {
+        const INLINE: usize = 16;
+        let key_ptrs: SmallVec<[*const c_char; INLINE]> =
+            key.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let key_lens: SmallVec<[size_t; INLINE]> = key.iter().map(|s| s.len()).collect();
+
+        let value_ptrs: SmallVec<[*const c_char; INLINE]> =
+            value.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let value_lens: SmallVec<[size_t; INLINE]> = value.iter().map(|s| s.len()).collect();
+
+        unsafe {
+            ffi::rocksdb_writebatch_putv_cf(
+                self.inner,
+                cf.inner(),
+                key.len() as libc::c_int,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                value.len() as libc::c_int,
+                value_ptrs.as_ptr(),
+                value_lens.as_ptr(),
+            );
+        }
+    }
+
     /// Insert a value into the specific column family of the database
     /// under the given key with timestamp.
     pub fn put_cf_with_ts<K, V, S>(&mut self, cf: &impl AsColumnFamilyRef, key: K, ts: S, value: V)
@@ -337,6 +395,31 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
         }
     }
 
+    /// Merge a value into the database using vectored I/O from multiple memory segments.
+    /// Avoids user-side copying when data spans multiple slices, though RocksDB still copies internally.
+    pub fn merge_vectored(&mut self, key: &[IoSlice<'_>], value: &[IoSlice<'_>]) {
+        const INLINE: usize = 16;
+        let key_ptrs: SmallVec<[*const c_char; INLINE]> =
+            key.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let key_lens: SmallVec<[size_t; INLINE]> = key.iter().map(|s| s.len()).collect();
+
+        let value_ptrs: SmallVec<[*const c_char; INLINE]> =
+            value.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let value_lens: SmallVec<[size_t; INLINE]> = value.iter().map(|s| s.len()).collect();
+
+        unsafe {
+            ffi::rocksdb_writebatch_mergev(
+                self.inner,
+                key.len() as libc::c_int,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                value.len() as libc::c_int,
+                value_ptrs.as_ptr(),
+                value_lens.as_ptr(),
+            );
+        }
+    }
+
     pub fn merge_cf<K, V>(&mut self, cf: &impl AsColumnFamilyRef, key: K, value: V)
     where
         K: AsRef<[u8]>,
@@ -353,6 +436,37 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
                 key.len() as size_t,
                 value.as_ptr() as *const c_char,
                 value.len() as size_t,
+            );
+        }
+    }
+
+    /// Merge a value into a column family using vectored I/O from multiple memory segments.
+    /// Avoids user-side copying when data spans multiple slices, though RocksDB still copies internally.
+    pub fn merge_cf_vectored(
+        &mut self,
+        cf: &impl AsColumnFamilyRef,
+        key: &[IoSlice<'_>],
+        value: &[IoSlice<'_>],
+    ) {
+        const INLINE: usize = 16;
+        let key_ptrs: SmallVec<[*const c_char; INLINE]> =
+            key.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let key_lens: SmallVec<[size_t; INLINE]> = key.iter().map(|s| s.len()).collect();
+
+        let value_ptrs: SmallVec<[*const c_char; INLINE]> =
+            value.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let value_lens: SmallVec<[size_t; INLINE]> = value.iter().map(|s| s.len()).collect();
+
+        unsafe {
+            ffi::rocksdb_writebatch_mergev_cf(
+                self.inner,
+                cf.inner(),
+                key.len() as libc::c_int,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                value.len() as libc::c_int,
+                value_ptrs.as_ptr(),
+                value_lens.as_ptr(),
             );
         }
     }

--- a/tests/test_write_batch.rs
+++ b/tests/test_write_batch.rs
@@ -17,7 +17,11 @@ use std::collections::HashMap;
 
 use pretty_assertions::assert_eq;
 
-use rust_rocksdb::{Error, WriteBatch, WriteBatchIterator, WriteBatchIteratorCf, DB};
+use rust_rocksdb::{
+    ColumnFamilyDescriptor, Error, Options, WriteBatch, WriteBatchIterator, WriteBatchIteratorCf,
+    DB,
+};
+use std::io::IoSlice;
 use util::DBPath;
 
 #[test]
@@ -147,4 +151,177 @@ fn test_write_batch_put_log_data() {
     }
 
     assert!(called);
+}
+
+#[test]
+fn test_write_batch_put_cf_vectored() {
+    let path = DBPath::new("writebatch_put_cf_vectored");
+    let db = DB::open_default(&path).unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"hello";
+    let key_part2 = b"_world";
+    let value_part1 = b"foo";
+    let value_part2 = b"_bar";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put_vectored(&key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get(b"hello_world").unwrap();
+    assert_eq!(retrieved.unwrap(), b"foo_bar");
+}
+
+#[test]
+fn test_write_batch_put_vectored() {
+    let path = DBPath::new("writebatch_put_vectored");
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+
+    let cf_descriptor = ColumnFamilyDescriptor::new("test_cf", Options::default());
+    let db = DB::open_cf_descriptors(&opts, &path, vec![cf_descriptor]).unwrap();
+
+    let cf = db.cf_handle("test_cf").unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"hello";
+    let key_part2 = b"_world";
+    let value_part1 = b"foo";
+    let value_part2 = b"_bar";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put_cf_vectored(&cf, &key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get_cf(&cf, b"hello_world").unwrap();
+    assert_eq!(retrieved.unwrap(), b"foo_bar");
+}
+
+#[test]
+fn test_write_batch_merge_cf_vectored() {
+    fn test_merge_operator(
+        _new_key: &[u8],
+        existing_val: Option<&[u8]>,
+        operands: &rust_rocksdb::MergeOperands,
+    ) -> Option<Vec<u8>> {
+        let mut result: Vec<u8> = Vec::new();
+        if let Some(v) = existing_val {
+            result.extend_from_slice(v);
+        }
+        for op in operands {
+            result.extend_from_slice(op);
+        }
+        Some(result)
+    }
+
+    let path = DBPath::new("writebatch_merge_cf_vectored");
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    opts.set_merge_operator_associative("test_merge", test_merge_operator);
+
+    let mut cf_opts = Options::default();
+    cf_opts.set_merge_operator_associative("test_merge", test_merge_operator);
+    let cf_descriptor = ColumnFamilyDescriptor::new("test_cf", cf_opts);
+    let db = DB::open_cf_descriptors(&opts, &path, vec![cf_descriptor]).unwrap();
+
+    let cf = db.cf_handle("test_cf").unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"merge";
+    let key_part2 = b"_key";
+    let value_part1 = b"val";
+    let value_part2 = b"ue";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put_cf(&cf, b"merge_key", b"initial");
+    batch.merge_cf_vectored(&cf, &key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get_cf(&cf, b"merge_key").unwrap();
+    assert_eq!(retrieved.unwrap(), b"initialvalue");
+}
+
+#[test]
+fn test_write_batch_put_vectored_no_cf() {
+    let path = DBPath::new("writebatch_put_vectored_no_cf");
+    let db = DB::open_default(&path).unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"hello";
+    let key_part2 = b"_world";
+    let value_part1 = b"foo";
+    let value_part2 = b"_bar";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put_vectored(&key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get(b"hello_world").unwrap();
+    assert_eq!(retrieved.unwrap(), b"foo_bar");
+}
+
+#[test]
+fn test_write_batch_merge_vectored_no_cf() {
+    fn test_merge_operator(
+        _new_key: &[u8],
+        existing_val: Option<&[u8]>,
+        operands: &rust_rocksdb::MergeOperands,
+    ) -> Option<Vec<u8>> {
+        let mut result: Vec<u8> = Vec::new();
+        if let Some(v) = existing_val {
+            result.extend_from_slice(v);
+        }
+        for op in operands {
+            result.extend_from_slice(op);
+        }
+        Some(result)
+    }
+
+    let path = DBPath::new("writebatch_merge_vectored_no_cf");
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.set_merge_operator_associative("test_merge", test_merge_operator);
+
+    let db = DB::open(&opts, &path).unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"merge";
+    let key_part2 = b"_key";
+    let value_part1 = b"val";
+    let value_part2 = b"ue";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put(b"merge_key", b"initial");
+    batch.merge_vectored(&key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get(b"merge_key").unwrap();
+    assert_eq!(retrieved.unwrap(), b"initialvalue");
 }


### PR DESCRIPTION
Introduces vectored writes to write batches.


This allows the caller to reduce the number of memory copies if their keys or values are already segmented in a rope-like buffer.

Pending: version bump.