### PR TITLE
Support for WriteBatch/WriteBatchWithIndex savepoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.43.1"
+version = "0.43.2"
 edition = "2021"
 rust-version = "1.81.0"
 authors = [

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{ffi, AsColumnFamilyRef};
+use crate::{ffi, AsColumnFamilyRef, Error};
 use libc::{c_char, c_void, size_t};
 use smallvec::SmallVec;
 use std::io::IoSlice;
@@ -348,6 +348,29 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
                 value_ptrs.as_ptr(),
                 value_lens.as_ptr(),
             );
+        }
+    }
+
+    /// Record the state of the operations for future calls to [`rollback_to_savepoint`].
+    /// May be called multiple times to set multiple save points.
+    ///
+    /// [`rollback_to_savepoint`]: Self::rollback_to_savepoint
+    pub fn set_savepoint(&mut self) {
+        unsafe {
+            ffi::rocksdb_writebatch_set_save_point(self.inner);
+        }
+    }
+
+    /// Undo all operations in this batch since the most recent call to [`set_savepoint`]
+    /// and removes the most recent [`set_savepoint`].
+    ///
+    /// Returns error if there is no previous call to [`set_savepoint`].
+    ///
+    /// [`set_savepoint`]: Self::set_savepoint
+    pub fn rollback_to_savepoint(&mut self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_writebatch_rollback_to_save_point(self.inner));
+            Ok(())
         }
     }
 

--- a/src/write_batch_with_index.rs
+++ b/src/write_batch_with_index.rs
@@ -34,6 +34,31 @@ impl WriteBatchWithIndex {
         }
     }
 
+    /// Record the state of the operations for future calls to [`rollback_to_savepoint`].
+    /// May be called multiple times to set multiple save points.
+    ///
+    /// [`rollback_to_savepoint`]: Self::rollback_to_savepoint
+    pub fn set_savepoint(&mut self) {
+        unsafe {
+            ffi::rocksdb_writebatch_wi_set_save_point(self.inner);
+        }
+    }
+
+    /// Undo all operations in this batch since the most recent call to [`set_savepoint`]
+    /// and removes the most recent [`set_savepoint`].
+    ///
+    /// Returns error if there is no previous call to [`set_savepoint`].
+    ///
+    /// [`set_savepoint`]: Self::set_savepoint
+    pub fn rollback_to_savepoint(&mut self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_writebatch_wi_rollback_to_save_point(
+                self.inner
+            ));
+            Ok(())
+        }
+    }
+
     /// Return a reference to a byte array which represents a serialized version of the batch.
     pub fn data(&self) -> &[u8] {
         unsafe {

--- a/tests/test_write_batch.rs
+++ b/tests/test_write_batch.rs
@@ -325,3 +325,31 @@ fn test_write_batch_merge_vectored_no_cf() {
     let retrieved = db.get(b"merge_key").unwrap();
     assert_eq!(retrieved.unwrap(), b"initialvalue");
 }
+
+#[test]
+fn test_write_batch_with_rollback_to_savepoint() {
+    let path = DBPath::new("writebatch_savepoint");
+    {
+        let db = DB::open_default(&path).expect("DB should open");
+
+        db.put(b"k1", b"v1").unwrap();
+        assert_eq!(db.get(b"k1").unwrap().unwrap(), b"v1");
+
+        let mut batch = WriteBatch::default();
+
+        batch.put(b"k1", b"v2");
+        batch.set_savepoint();
+        batch.put(b"k1", b"v3");
+        batch.set_savepoint();
+        batch.put(b"k1", b"v4");
+        // first rollback
+        batch.rollback_to_savepoint().unwrap();
+        // second rollback
+        batch.rollback_to_savepoint().unwrap();
+        // can't rollback more
+        assert!(batch.rollback_to_savepoint().is_err());
+        db.write(&batch).unwrap();
+
+        assert_eq!(db.get(b"k1").unwrap().unwrap(), b"v2");
+    }
+}

--- a/tests/test_write_batch_with_index.rs
+++ b/tests/test_write_batch_with_index.rs
@@ -36,3 +36,69 @@ fn test_write_batch_with_index_with_base_iterator() {
         assert_no_item(&iterator);
     }
 }
+
+#[test]
+fn test_write_batch_with_index_with_rollback_to_savepoint() {
+    let path = DBPath::new("_rust_rocksdb_wbwi_savepoint");
+    {
+        let db = DB::open_default(&path).expect("DB should open");
+
+        db.put(b"k1", b"v1").unwrap();
+        assert_eq!(db.get(b"k1").unwrap().unwrap(), b"v1");
+
+        let mut wbwi = WriteBatchWithIndex::new(0, true);
+
+        let readopts = ReadOptions::default();
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v1"
+        );
+        wbwi.put(b"k1", b"v2");
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v2"
+        );
+        wbwi.set_savepoint();
+        wbwi.put(b"k1", b"v3");
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v3"
+        );
+        wbwi.set_savepoint();
+        wbwi.put(b"k1", b"v4");
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v4"
+        );
+        // first rollback
+        wbwi.rollback_to_savepoint().unwrap();
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v3"
+        );
+        // second rollback
+        wbwi.rollback_to_savepoint().unwrap();
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v2"
+        );
+
+        // can't rollback more
+        assert!(wbwi.rollback_to_savepoint().is_err());
+        db.write_wbwi(&wbwi).unwrap();
+
+        assert_eq!(db.get(b"k1").unwrap().unwrap(), b"v2");
+    }
+}


### PR DESCRIPTION
Adds support for recording one or more save-points in a write batch or WBWI to allow for opportunistic application of batched operations without sacrificing atomicity of sub-batches.