### PR TITLE
Replace eager column family metadata with lazy reference wrappers 

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2851,44 +2851,38 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         }
     }
 
-    /// Obtains the LSM-tree meta data of the default column family of the DB
-    pub fn get_column_family_metadata(&self) -> ColumnFamilyMetaData {
+    /// Obtains the LSM-tree meta data of the default column family of the DB.
+    ///
+    /// Returns a wrapper that provides lazy access to the metadata fields.
+    /// The metadata is fetched from RocksDB only when accessor methods are called.
+    ///
+    /// The returned reference is tied to the lifetime of the database.
+    pub fn get_column_family_metadata(&self) -> ColumnFamilyMetaDataRef<'_> {
         unsafe {
             let ptr = ffi::rocksdb_get_column_family_metadata(self.inner.inner());
-
-            let metadata = ColumnFamilyMetaData {
-                size: ffi::rocksdb_column_family_metadata_get_size(ptr),
-                name: from_cstr_and_free(ffi::rocksdb_column_family_metadata_get_name(ptr)),
-                file_count: ffi::rocksdb_column_family_metadata_get_file_count(ptr),
-            };
-
-            // destroy
-            ffi::rocksdb_column_family_metadata_destroy(ptr);
-
-            // return
-            metadata
+            ColumnFamilyMetaDataRef {
+                ptr,
+                _marker: std::marker::PhantomData,
+            }
         }
     }
 
-    /// Obtains the LSM-tree meta data of the specified column family of the DB
+    /// Obtains the LSM-tree meta data of the specified column family of the DB.
+    ///
+    /// Returns a wrapper that provides lazy access to the metadata fields.
+    /// The metadata is fetched from RocksDB only when accessor methods are called.
+    ///
+    /// The returned reference is tied to the lifetime of the database.
     pub fn get_column_family_metadata_cf(
         &self,
         cf: &impl AsColumnFamilyRef,
-    ) -> ColumnFamilyMetaData {
+    ) -> ColumnFamilyMetaDataRef<'_> {
         unsafe {
             let ptr = ffi::rocksdb_get_column_family_metadata_cf(self.inner.inner(), cf.inner());
-
-            let metadata = ColumnFamilyMetaData {
-                size: ffi::rocksdb_column_family_metadata_get_size(ptr),
-                name: from_cstr_and_free(ffi::rocksdb_column_family_metadata_get_name(ptr)),
-                file_count: ffi::rocksdb_column_family_metadata_get_file_count(ptr),
-            };
-
-            // destroy
-            ffi::rocksdb_column_family_metadata_destroy(ptr);
-
-            // return
-            metadata
+            ColumnFamilyMetaDataRef {
+                ptr,
+                _marker: std::marker::PhantomData,
+            }
         }
     }
 
@@ -3187,16 +3181,196 @@ impl<T: ThreadMode, I: DBInner> fmt::Debug for DBCommon<T, I> {
     }
 }
 
-/// The metadata that describes a column family.
-#[derive(Debug, Clone)]
-pub struct ColumnFamilyMetaData {
-    // The size of this column family in bytes, which is equal to the sum of
-    // the file size of its "levels".
-    pub size: u64,
-    // The name of the column family.
-    pub name: String,
-    // The number of files in this column family.
-    pub file_count: usize,
+/// A wrapper around a RocksDB SST file metadata pointer.
+///
+/// This struct provides lazy access to SST file metadata fields.
+/// The lifetime `'a` is tied to the parent `LevelMetaDataRef`.
+pub struct SstFileMetaDataRef<'a> {
+    ptr: *mut ffi::rocksdb_sst_file_metadata_t,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl SstFileMetaDataRef<'_> {
+    /// Returns the relative file name without the directory path.
+    pub fn relative_filename(&self) -> String {
+        unsafe {
+            from_cstr_and_free(ffi::rocksdb_sst_file_metadata_get_relative_filename(
+                self.ptr,
+            ))
+        }
+    }
+
+    /// Returns the directory containing this file.
+    pub fn directory(&self) -> String {
+        unsafe { from_cstr_and_free(ffi::rocksdb_sst_file_metadata_get_directory(self.ptr)) }
+    }
+
+    /// Returns the size of the file in bytes.
+    pub fn size(&self) -> u64 {
+        unsafe { ffi::rocksdb_sst_file_metadata_get_size(self.ptr) }
+    }
+
+    /// Returns the smallest user key in the file.
+    pub fn smallest_key(&self) -> Option<Vec<u8>> {
+        unsafe {
+            let mut key_len: size_t = 0;
+            let key_ptr =
+                ffi::rocksdb_sst_file_metadata_get_smallestkey(self.ptr, &raw mut key_len);
+            if key_ptr.is_null() {
+                None
+            } else {
+                let key = std::slice::from_raw_parts(key_ptr as *const u8, key_len).to_vec();
+                ffi::rocksdb_free(key_ptr as *mut c_void);
+                Some(key)
+            }
+        }
+    }
+
+    /// Returns the largest user key in the file.
+    pub fn largest_key(&self) -> Option<Vec<u8>> {
+        unsafe {
+            let mut key_len: size_t = 0;
+            let key_ptr = ffi::rocksdb_sst_file_metadata_get_largestkey(self.ptr, &raw mut key_len);
+            if key_ptr.is_null() {
+                None
+            } else {
+                let key = std::slice::from_raw_parts(key_ptr as *const u8, key_len).to_vec();
+                ffi::rocksdb_free(key_ptr as *mut c_void);
+                Some(key)
+            }
+        }
+    }
+}
+
+impl Drop for SstFileMetaDataRef<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_sst_file_metadata_destroy(self.ptr);
+        }
+    }
+}
+
+/// A wrapper around a RocksDB level metadata pointer.
+///
+/// This struct provides lazy access to level metadata fields.
+/// The lifetime `'a` is tied to the parent `ColumnFamilyMetaDataRef`.
+pub struct LevelMetaDataRef<'a> {
+    ptr: *mut ffi::rocksdb_level_metadata_t,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl LevelMetaDataRef<'_> {
+    /// Returns the level number.
+    pub fn level(&self) -> i32 {
+        unsafe { ffi::rocksdb_level_metadata_get_level(self.ptr) }
+    }
+
+    /// Returns the size of this level in bytes.
+    pub fn size(&self) -> u64 {
+        unsafe { ffi::rocksdb_level_metadata_get_size(self.ptr) }
+    }
+
+    /// Returns the number of SST files in this level.
+    pub fn file_count(&self) -> usize {
+        unsafe { ffi::rocksdb_level_metadata_get_file_count(self.ptr) }
+    }
+
+    /// Returns the metadata for the SST file at the given index.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    pub fn file(&self, index: usize) -> Option<SstFileMetaDataRef<'_>> {
+        unsafe {
+            let file_ptr = ffi::rocksdb_level_metadata_get_sst_file_metadata(self.ptr, index);
+            if file_ptr.is_null() {
+                None
+            } else {
+                Some(SstFileMetaDataRef {
+                    ptr: file_ptr,
+                    _marker: std::marker::PhantomData,
+                })
+            }
+        }
+    }
+
+    /// Returns an iterator over all SST files in this level.
+    pub fn files(&self) -> impl Iterator<Item = SstFileMetaDataRef<'_>> {
+        let count = self.file_count();
+        (0..count).filter_map(move |i| self.file(i))
+    }
+}
+
+impl Drop for LevelMetaDataRef<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_level_metadata_destroy(self.ptr);
+        }
+    }
+}
+
+/// A wrapper around a RocksDB column family metadata pointer.
+///
+/// This struct provides lazy access to column family metadata fields,
+/// including per-level and per-file metadata. The metadata is fetched
+/// from RocksDB only when the corresponding accessor method is called.
+///
+/// The lifetime `'a` is tied to the database from which this metadata was obtained,
+/// ensuring the metadata reference does not outlive the database.
+pub struct ColumnFamilyMetaDataRef<'a> {
+    ptr: *mut ffi::rocksdb_column_family_metadata_t,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl ColumnFamilyMetaDataRef<'_> {
+    /// Returns the size of this column family in bytes.
+    pub fn size(&self) -> u64 {
+        unsafe { ffi::rocksdb_column_family_metadata_get_size(self.ptr) }
+    }
+
+    /// Returns the name of the column family.
+    pub fn name(&self) -> String {
+        unsafe { from_cstr_and_free(ffi::rocksdb_column_family_metadata_get_name(self.ptr)) }
+    }
+
+    /// Returns the number of files in this column family.
+    pub fn file_count(&self) -> usize {
+        unsafe { ffi::rocksdb_column_family_metadata_get_file_count(self.ptr) }
+    }
+
+    /// Returns the number of levels in this column family.
+    pub fn level_count(&self) -> usize {
+        unsafe { ffi::rocksdb_column_family_metadata_get_level_count(self.ptr) }
+    }
+
+    /// Returns the metadata for the level at the given index.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    pub fn level(&self, index: usize) -> Option<LevelMetaDataRef<'_>> {
+        unsafe {
+            let level_ptr = ffi::rocksdb_column_family_metadata_get_level_metadata(self.ptr, index);
+            if level_ptr.is_null() {
+                None
+            } else {
+                Some(LevelMetaDataRef {
+                    ptr: level_ptr,
+                    _marker: std::marker::PhantomData,
+                })
+            }
+        }
+    }
+
+    /// Returns an iterator over all levels in this column family.
+    pub fn levels(&self) -> impl Iterator<Item = LevelMetaDataRef<'_>> {
+        let count = self.level_count();
+        (0..count).filter_map(move |i| self.level(i))
+    }
+}
+
+impl Drop for ColumnFamilyMetaDataRef<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_column_family_metadata_destroy(self.ptr);
+        }
+    }
 }
 
 /// The metadata that describes a SST file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,9 @@ pub use crate::{
     },
     compaction_filter::Decision as CompactionDecision,
     db::{
-        DB, DBAccess, DBCommon, DBWithThreadMode, ExportImportFilesMetaData, LiveFile,
-        MultiThreaded, PrefixProber, Range, SingleThreaded, ThreadMode,
+        ColumnFamilyMetaDataRef, DB, DBAccess, DBCommon, DBWithThreadMode,
+        ExportImportFilesMetaData, LevelMetaDataRef, LiveFile, MultiThreaded, PrefixProber, Range,
+        SingleThreaded, SstFileMetaDataRef, ThreadMode,
     },
     db_iterator::{
         DBIterator, DBIteratorWithThreadMode, DBRawIterator, DBRawIteratorWithThreadMode,

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -440,12 +440,61 @@ fn set_column_family_metadata_test() {
         db.flush_cf(&cf2).unwrap();
 
         let default_cf_metadata = db.get_column_family_metadata();
-        assert_eq!(default_cf_metadata.size > 150, true);
-        assert_eq!(default_cf_metadata.file_count, 1);
+        let default_cf_size = default_cf_metadata.size();
+        assert!(default_cf_size > 150);
+        assert_eq!(default_cf_metadata.file_count(), 1);
+        assert_eq!(default_cf_metadata.name(), DEFAULT_COLUMN_FAMILY_NAME);
+
+        // Verify level metadata using lazy accessors
+        assert!(default_cf_metadata.level_count() > 0);
+
+        // After flush, data should be in L0 (level 0)
+        // Calculate total size from levels
+        let total_level_size: u64 = default_cf_metadata.levels().map(|l| l.size()).sum();
+        assert_eq!(default_cf_size, total_level_size);
+
+        // Find the level with files (should be L0 after flush)
+        let levels_with_files_count = default_cf_metadata
+            .levels()
+            .filter(|l| l.file_count() > 0)
+            .count();
+        assert!(levels_with_files_count > 0);
+
+        // Verify SST file metadata using lazy accessors
+        for level in default_cf_metadata.levels() {
+            for file in level.files() {
+                assert!(!file.relative_filename().is_empty());
+                assert!(!file.directory().is_empty());
+                assert!(file.size() > 0);
+                // After flush, files should have keys
+                assert!(file.smallest_key().is_some());
+                assert!(file.largest_key().is_some());
+            }
+        }
 
         let cf2_metadata = db.get_column_family_metadata_cf(&cf2);
-        assert_eq!(cf2_metadata.size > default_cf_metadata.size, true);
-        assert_eq!(cf2_metadata.file_count, 1);
+        assert!(cf2_metadata.size() > default_cf_size);
+        assert_eq!(cf2_metadata.file_count(), 1);
+        assert_eq!(cf2_metadata.name(), "cf2");
+
+        // Verify cf2 level metadata
+        assert!(cf2_metadata.level_count() > 0);
+        let cf2_total_level_size: u64 = cf2_metadata.levels().map(|l| l.size()).sum();
+        assert_eq!(cf2_metadata.size(), cf2_total_level_size);
+
+        // Verify cf2 has files with expected keys
+        // Find a level with files and check the first file
+        let mut found_file = false;
+        for level in cf2_metadata.levels() {
+            if let Some(file) = level.file(0) {
+                // cf2 should have keys key1, key2, key3 so smallest should be key1 and largest key3
+                assert_eq!(file.smallest_key().as_deref(), Some(b"key1".as_slice()));
+                assert_eq!(file.largest_key().as_deref(), Some(b"key3".as_slice()));
+                found_file = true;
+                break;
+            }
+        }
+        assert!(found_file, "cf2 should have at least one file");
     }
 }
 


### PR DESCRIPTION
Replace the eagerly-loaded ColumnFamilyMetaData, LevelMetaData, and SstFileMetaData structs with lazy wrapper types (ColumnFamilyMetaDataRef, LevelMetaDataRef, SstFileMetaDataRef) that fetch metadata from RocksDB on-demand.

Key changes:
- Metadata fields are now accessed via method calls instead of public fields
- Each wrapper holds a raw pointer and is tied to its parent's lifetime
- Memory is properly cleaned up via Drop implementations
- Iterators provided for traversing levels and files (levels(), files())
- Index-based accessors for random access (level(i), file(i))
- New fields exposed: level_count() on column families, file_count() on levels

This improves performance when only a subset of metadata is needed, as data is no longer eagerly copied from RocksDB into Rust collections upfront.