### PR TITLE
Add ReadOptions::set_table_filter for skipping SSTs during iteration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/google/snappy.git
 [submodule "rocksdb_sys/rocksdb"]
 	path = librocksdb-sys/rocksdb
-	url = https://github.com/facebook/rocksdb.git
+	url = https://github.com/restatedev/rocksdb.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rust-librocksdb-sys = { path = "librocksdb-sys", version = "0.41.0", default-fea
     "static",
 ] }
 serde = { version = "1", features = ["derive"], optional = true }
+smallvec = { version = "1" }
 parking_lot = { version = "0.12" }
 smartstring = { version = "1.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ rust-librocksdb-sys = { path = "librocksdb-sys", version = "0.41.0", default-fea
 ] }
 serde = { version = "1", features = ["derive"], optional = true }
 parking_lot = { version = "0.12" }
+smartstring = { version = "1.0" }
+
 
 [dev-dependencies]
 trybuild = "1"

--- a/src/db.rs
+++ b/src/db.rs
@@ -3093,7 +3093,7 @@ impl<I: DBInner> DBCommon<SingleThreaded, I> {
     ///
     /// The order of names is unspecified and may vary between calls.
     pub fn cf_names(&self) -> Vec<String> {
-        self.cfs.cfs.keys().cloned().collect()
+        self.cfs.cfs.keys().map(ToString::to_string).collect()
     }
 }
 
@@ -3166,7 +3166,12 @@ impl<I: DBInner> DBCommon<MultiThreaded, I> {
     ///
     /// The order of names is unspecified and may vary between calls.
     pub fn cf_names(&self) -> Vec<String> {
-        self.cfs.cfs.read().keys().cloned().collect()
+        self.cfs
+            .cfs
+            .read()
+            .keys()
+            .map(ToString::to_string)
+            .collect()
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -2851,44 +2851,38 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         }
     }
 
-    /// Obtains the LSM-tree meta data of the default column family of the DB
-    pub fn get_column_family_metadata(&self) -> ColumnFamilyMetaData {
+    /// Obtains the LSM-tree meta data of the default column family of the DB.
+    ///
+    /// Returns a wrapper that provides lazy access to the metadata fields.
+    /// The metadata is fetched from RocksDB only when accessor methods are called.
+    ///
+    /// The returned reference is tied to the lifetime of the database.
+    pub fn get_column_family_metadata(&self) -> ColumnFamilyMetaDataRef<'_> {
         unsafe {
             let ptr = ffi::rocksdb_get_column_family_metadata(self.inner.inner());
-
-            let metadata = ColumnFamilyMetaData {
-                size: ffi::rocksdb_column_family_metadata_get_size(ptr),
-                name: from_cstr_and_free(ffi::rocksdb_column_family_metadata_get_name(ptr)),
-                file_count: ffi::rocksdb_column_family_metadata_get_file_count(ptr),
-            };
-
-            // destroy
-            ffi::rocksdb_column_family_metadata_destroy(ptr);
-
-            // return
-            metadata
+            ColumnFamilyMetaDataRef {
+                ptr,
+                _marker: std::marker::PhantomData,
+            }
         }
     }
 
-    /// Obtains the LSM-tree meta data of the specified column family of the DB
+    /// Obtains the LSM-tree meta data of the specified column family of the DB.
+    ///
+    /// Returns a wrapper that provides lazy access to the metadata fields.
+    /// The metadata is fetched from RocksDB only when accessor methods are called.
+    ///
+    /// The returned reference is tied to the lifetime of the database.
     pub fn get_column_family_metadata_cf(
         &self,
         cf: &impl AsColumnFamilyRef,
-    ) -> ColumnFamilyMetaData {
+    ) -> ColumnFamilyMetaDataRef<'_> {
         unsafe {
             let ptr = ffi::rocksdb_get_column_family_metadata_cf(self.inner.inner(), cf.inner());
-
-            let metadata = ColumnFamilyMetaData {
-                size: ffi::rocksdb_column_family_metadata_get_size(ptr),
-                name: from_cstr_and_free(ffi::rocksdb_column_family_metadata_get_name(ptr)),
-                file_count: ffi::rocksdb_column_family_metadata_get_file_count(ptr),
-            };
-
-            // destroy
-            ffi::rocksdb_column_family_metadata_destroy(ptr);
-
-            // return
-            metadata
+            ColumnFamilyMetaDataRef {
+                ptr,
+                _marker: std::marker::PhantomData,
+            }
         }
     }
 
@@ -3187,16 +3181,196 @@ impl<T: ThreadMode, I: DBInner> fmt::Debug for DBCommon<T, I> {
     }
 }
 
-/// The metadata that describes a column family.
-#[derive(Debug, Clone)]
-pub struct ColumnFamilyMetaData {
-    // The size of this column family in bytes, which is equal to the sum of
-    // the file size of its "levels".
-    pub size: u64,
-    // The name of the column family.
-    pub name: String,
-    // The number of files in this column family.
-    pub file_count: usize,
+/// A wrapper around a RocksDB SST file metadata pointer.
+///
+/// This struct provides lazy access to SST file metadata fields.
+/// The lifetime `'a` is tied to the parent `LevelMetaDataRef`.
+pub struct SstFileMetaDataRef<'a> {
+    ptr: *mut ffi::rocksdb_sst_file_metadata_t,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl SstFileMetaDataRef<'_> {
+    /// Returns the relative file name without the directory path.
+    pub fn relative_filename(&self) -> String {
+        unsafe {
+            from_cstr_and_free(ffi::rocksdb_sst_file_metadata_get_relative_filename(
+                self.ptr,
+            ))
+        }
+    }
+
+    /// Returns the directory containing this file.
+    pub fn directory(&self) -> String {
+        unsafe { from_cstr_and_free(ffi::rocksdb_sst_file_metadata_get_directory(self.ptr)) }
+    }
+
+    /// Returns the size of the file in bytes.
+    pub fn size(&self) -> u64 {
+        unsafe { ffi::rocksdb_sst_file_metadata_get_size(self.ptr) }
+    }
+
+    /// Returns the smallest user key in the file.
+    pub fn smallest_key(&self) -> Option<Vec<u8>> {
+        unsafe {
+            let mut key_len: size_t = 0;
+            let key_ptr =
+                ffi::rocksdb_sst_file_metadata_get_smallestkey(self.ptr, &raw mut key_len);
+            if key_ptr.is_null() {
+                None
+            } else {
+                let key = std::slice::from_raw_parts(key_ptr as *const u8, key_len).to_vec();
+                ffi::rocksdb_free(key_ptr as *mut c_void);
+                Some(key)
+            }
+        }
+    }
+
+    /// Returns the largest user key in the file.
+    pub fn largest_key(&self) -> Option<Vec<u8>> {
+        unsafe {
+            let mut key_len: size_t = 0;
+            let key_ptr = ffi::rocksdb_sst_file_metadata_get_largestkey(self.ptr, &raw mut key_len);
+            if key_ptr.is_null() {
+                None
+            } else {
+                let key = std::slice::from_raw_parts(key_ptr as *const u8, key_len).to_vec();
+                ffi::rocksdb_free(key_ptr as *mut c_void);
+                Some(key)
+            }
+        }
+    }
+}
+
+impl Drop for SstFileMetaDataRef<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_sst_file_metadata_destroy(self.ptr);
+        }
+    }
+}
+
+/// A wrapper around a RocksDB level metadata pointer.
+///
+/// This struct provides lazy access to level metadata fields.
+/// The lifetime `'a` is tied to the parent `ColumnFamilyMetaDataRef`.
+pub struct LevelMetaDataRef<'a> {
+    ptr: *mut ffi::rocksdb_level_metadata_t,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl LevelMetaDataRef<'_> {
+    /// Returns the level number.
+    pub fn level(&self) -> i32 {
+        unsafe { ffi::rocksdb_level_metadata_get_level(self.ptr) }
+    }
+
+    /// Returns the size of this level in bytes.
+    pub fn size(&self) -> u64 {
+        unsafe { ffi::rocksdb_level_metadata_get_size(self.ptr) }
+    }
+
+    /// Returns the number of SST files in this level.
+    pub fn file_count(&self) -> usize {
+        unsafe { ffi::rocksdb_level_metadata_get_file_count(self.ptr) }
+    }
+
+    /// Returns the metadata for the SST file at the given index.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    pub fn file(&self, index: usize) -> Option<SstFileMetaDataRef<'_>> {
+        unsafe {
+            let file_ptr = ffi::rocksdb_level_metadata_get_sst_file_metadata(self.ptr, index);
+            if file_ptr.is_null() {
+                None
+            } else {
+                Some(SstFileMetaDataRef {
+                    ptr: file_ptr,
+                    _marker: std::marker::PhantomData,
+                })
+            }
+        }
+    }
+
+    /// Returns an iterator over all SST files in this level.
+    pub fn files(&self) -> impl Iterator<Item = SstFileMetaDataRef<'_>> {
+        let count = self.file_count();
+        (0..count).filter_map(move |i| self.file(i))
+    }
+}
+
+impl Drop for LevelMetaDataRef<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_level_metadata_destroy(self.ptr);
+        }
+    }
+}
+
+/// A wrapper around a RocksDB column family metadata pointer.
+///
+/// This struct provides lazy access to column family metadata fields,
+/// including per-level and per-file metadata. The metadata is fetched
+/// from RocksDB only when the corresponding accessor method is called.
+///
+/// The lifetime `'a` is tied to the database from which this metadata was obtained,
+/// ensuring the metadata reference does not outlive the database.
+pub struct ColumnFamilyMetaDataRef<'a> {
+    ptr: *mut ffi::rocksdb_column_family_metadata_t,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl ColumnFamilyMetaDataRef<'_> {
+    /// Returns the size of this column family in bytes.
+    pub fn size(&self) -> u64 {
+        unsafe { ffi::rocksdb_column_family_metadata_get_size(self.ptr) }
+    }
+
+    /// Returns the name of the column family.
+    pub fn name(&self) -> String {
+        unsafe { from_cstr_and_free(ffi::rocksdb_column_family_metadata_get_name(self.ptr)) }
+    }
+
+    /// Returns the number of files in this column family.
+    pub fn file_count(&self) -> usize {
+        unsafe { ffi::rocksdb_column_family_metadata_get_file_count(self.ptr) }
+    }
+
+    /// Returns the number of levels in this column family.
+    pub fn level_count(&self) -> usize {
+        unsafe { ffi::rocksdb_column_family_metadata_get_level_count(self.ptr) }
+    }
+
+    /// Returns the metadata for the level at the given index.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    pub fn level(&self, index: usize) -> Option<LevelMetaDataRef<'_>> {
+        unsafe {
+            let level_ptr = ffi::rocksdb_column_family_metadata_get_level_metadata(self.ptr, index);
+            if level_ptr.is_null() {
+                None
+            } else {
+                Some(LevelMetaDataRef {
+                    ptr: level_ptr,
+                    _marker: std::marker::PhantomData,
+                })
+            }
+        }
+    }
+
+    /// Returns an iterator over all levels in this column family.
+    pub fn levels(&self) -> impl Iterator<Item = LevelMetaDataRef<'_>> {
+        let count = self.level_count();
+        (0..count).filter_map(move |i| self.level(i))
+    }
+}
+
+impl Drop for ColumnFamilyMetaDataRef<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_column_family_metadata_destroy(self.ptr);
+        }
+    }
 }
 
 /// The metadata that describes a SST file

--- a/src/db.rs
+++ b/src/db.rs
@@ -97,6 +97,8 @@ impl<D: DBAccess> PrefixProber<'_, D> {
     }
 }
 
+pub(crate) type CompactString = smartstring::SmartString<smartstring::LazyCompact>;
+
 /// Marker trait to specify single or multi threaded column family alternations for
 /// [`DBWithThreadMode<T>`]
 ///
@@ -110,7 +112,7 @@ impl<D: DBAccess> PrefixProber<'_, D> {
 pub trait ThreadMode {
     /// Internal implementation for storing column family handles
     fn new_cf_map_internal(
-        cf_map: BTreeMap<String, *mut ffi::rocksdb_column_family_handle_t>,
+        cf_map: BTreeMap<CompactString, *mut ffi::rocksdb_column_family_handle_t>,
     ) -> Self;
     /// Internal implementation for dropping column family handles
     fn drop_all_cfs_internal(&mut self);
@@ -123,7 +125,7 @@ pub trait ThreadMode {
 ///
 /// See [`DB`] for more details, including performance implications for each mode
 pub struct SingleThreaded {
-    pub(crate) cfs: HashMap<String, ColumnFamily>,
+    pub(crate) cfs: HashMap<CompactString, ColumnFamily>,
 }
 
 /// Actual marker type for the marker trait `ThreadMode`, which holds
@@ -132,12 +134,12 @@ pub struct SingleThreaded {
 ///
 /// See [`DB`] for more details, including performance implications for each mode
 pub struct MultiThreaded {
-    pub(crate) cfs: RwLock<HashMap<String, Arc<UnboundColumnFamily>>>,
+    pub(crate) cfs: RwLock<HashMap<CompactString, Arc<UnboundColumnFamily>>>,
 }
 
 impl ThreadMode for SingleThreaded {
     fn new_cf_map_internal(
-        cfs: BTreeMap<String, *mut ffi::rocksdb_column_family_handle_t>,
+        cfs: BTreeMap<CompactString, *mut ffi::rocksdb_column_family_handle_t>,
     ) -> Self {
         Self {
             cfs: cfs
@@ -155,7 +157,7 @@ impl ThreadMode for SingleThreaded {
 
 impl ThreadMode for MultiThreaded {
     fn new_cf_map_internal(
-        cfs: BTreeMap<String, *mut ffi::rocksdb_column_family_handle_t>,
+        cfs: BTreeMap<CompactString, *mut ffi::rocksdb_column_family_handle_t>,
     ) -> Self {
         Self {
             cfs: RwLock::new(
@@ -741,7 +743,7 @@ impl<T: ThreadMode> DBWithThreadMode<T> {
             }
 
             for (cf_desc, inner) in cfs_v.iter().zip(cfhandles) {
-                cf_map.insert(cf_desc.name.clone(), inner);
+                cf_map.insert(cf_desc.name.clone().into(), inner);
             }
         }
 
@@ -3041,7 +3043,7 @@ impl<I: DBInner> DBCommon<SingleThreaded, I> {
         let inner = self.create_inner_cf_handle(name.as_ref(), opts)?;
         self.cfs
             .cfs
-            .insert(name.as_ref().to_string(), ColumnFamily { inner });
+            .insert(name.as_ref().into(), ColumnFamily { inner });
         Ok(())
     }
 
@@ -3103,7 +3105,7 @@ impl<I: DBInner> DBCommon<MultiThreaded, I> {
         let mut cfs = self.cfs.cfs.write();
         let inner = self.create_inner_cf_handle(name.as_ref(), opts)?;
         cfs.insert(
-            name.as_ref().to_string(),
+            name.as_ref().into(),
             Arc::new(UnboundColumnFamily { inner }),
         );
         Ok(())
@@ -3135,7 +3137,7 @@ impl<I: DBInner> DBCommon<MultiThreaded, I> {
             ))
         };
         cfs.insert(
-            column_family_name.as_ref().to_string(),
+            column_family_name.as_ref().into(),
             Arc::new(UnboundColumnFamily { inner }),
         );
         Ok(())

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -43,6 +43,7 @@ use crate::{
     },
     slice_transform::SliceTransform,
     statistics::Ticker,
+    table_properties::TableProperties,
 };
 
 // must be Send and Sync because it will be called by RocksDB from different threads
@@ -4388,6 +4389,38 @@ impl ReadOptions {
         self.iter_start_ts = ts;
         unsafe {
             ffi::rocksdb_readoptions_set_iter_start_ts(self.inner, ptr, len);
+        }
+    }
+
+    /// Sets a table filter callback that is invoked for each SST file during
+    /// iteration. Return `false` to skip scanning a table entirely. This only
+    /// affects iterators, not point lookups.
+    pub fn set_table_filter<F>(&mut self, filter: F)
+    where
+        F: Fn(&TableProperties) -> bool + Send + Sync + 'static,
+    {
+        type FilterFn = Box<dyn Fn(&TableProperties) -> bool + Send + Sync>;
+
+        unsafe extern "C" fn call(
+            state: *mut c_void,
+            props: *const ffi::rocksdb_table_properties_t,
+        ) -> c_uchar {
+            let filter = unsafe { &**(state as *const FilterFn) };
+            let props = unsafe { TableProperties::from_raw(props) };
+            c_uchar::from(filter(&props))
+        }
+
+        unsafe extern "C" fn destroy(state: *mut c_void) {
+            drop(unsafe { Box::from_raw(state as *mut FilterFn) });
+        }
+
+        // Double-box: the outer Box<FilterFn> gives us a thin pointer we
+        // can round-trip through *mut c_void in the C callbacks.
+        let boxed: Box<FilterFn> = Box::new(Box::new(filter));
+        let state = Box::into_raw(boxed) as *mut c_void;
+
+        unsafe {
+            ffi::rocksdb_readoptions_set_table_filter(self.inner, state, Some(call), Some(destroy));
         }
     }
 }

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -1,6 +1,10 @@
-use crate::ffi_util::convert_rocksdb_error;
-use crate::{Error, ffi};
+use std::ffi::CStr;
+use std::ptr::NonNull;
+
 use libc::{c_char, c_void};
+
+use crate::ffi_util::{convert_rocksdb_error, error_message};
+use crate::{ffi, CStrLike, Error};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(C)]
@@ -216,6 +220,11 @@ impl From<u32> for DBBackgroundErrorReason {
 
 pub struct FlushJobInfo {
     pub(crate) inner: *const ffi::rocksdb_flushjobinfo_t,
+
+    // Holds a pointer to data borrowed from RocksDB for the duration of the event handler callback;
+    // we are responsible for freeing the wrapper struct. The lifetime of the struct is the same as
+    // the inner flushjobinfo_t instance.
+    table_properties: NonNull<ffi::rocksdb_table_properties_t>,
 }
 
 impl FlushJobInfo {
@@ -255,6 +264,60 @@ impl FlushJobInfo {
 
     pub fn flush_reason(&self) -> DBFlushReason {
         unsafe { DBFlushReason::from(ffi::rocksdb_flushjobinfo_flush_reason(self.inner)) }
+    }
+}
+
+impl FlushJobInfo {
+    pub fn get_user_collected_property(&self, key: impl CStrLike) -> Option<&CStr> {
+        unsafe {
+            let key_cstring = key.into_c_string().unwrap();
+            let value_ptr = ffi::rocksdb_table_properties_get_user_collected_property(
+                self.table_properties.as_ptr(),
+                key_cstring.as_ptr(),
+            );
+
+            if value_ptr.is_null() {
+                return None;
+            }
+
+            let value_string = CStr::from_ptr(value_ptr);
+            Some(value_string)
+        }
+    }
+
+    pub fn get_user_collected_property_keys(&self, prefix: impl CStrLike) -> Vec<&CStr> {
+        unsafe {
+            let mut key_count: usize = 0;
+            let prefix = prefix.into_c_string().unwrap();
+            let keys_ptr = ffi::rocksdb_table_properties_get_user_collected_property_keys(
+                self.table_properties.as_ptr(),
+                prefix.as_ptr(),
+                &mut key_count,
+            );
+
+            if keys_ptr.is_null() {
+                return Vec::new();
+            }
+
+            let mut result = Vec::with_capacity(key_count);
+            for i in 0..key_count {
+                let key_ptr = *keys_ptr.add(i);
+                if !key_ptr.is_null() {
+                    result.push(CStr::from_ptr(key_ptr));
+                }
+            }
+            ffi::rocksdb_free(keys_ptr as *mut c_void);
+
+            result
+        }
+    }
+}
+
+impl Drop for FlushJobInfo {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_table_properties_destroy(self.table_properties.as_ptr());
+        }
     }
 }
 
@@ -525,7 +588,11 @@ unsafe extern "C" fn on_flush_begin<E: EventListener>(
     info: *const ffi::rocksdb_flushjobinfo_t,
 ) {
     let ctx = unsafe { &*(ctx as *mut E) };
-    let info = FlushJobInfo { inner: info };
+    let table_properties = unsafe { ffi::rocksdb_flushjobinfo_table_properties(info).cast_mut() };
+    let info = FlushJobInfo {
+        inner: info,
+        table_properties: NonNull::new(table_properties).unwrap(),
+    };
     ctx.on_flush_begin(&info);
 }
 
@@ -535,7 +602,11 @@ extern "C" fn on_flush_completed<E: EventListener>(
     info: *const ffi::rocksdb_flushjobinfo_t,
 ) {
     let ctx = unsafe { &*(ctx as *mut E) };
-    let info = FlushJobInfo { inner: info };
+    let table_properties = unsafe { ffi::rocksdb_flushjobinfo_table_properties(info).cast_mut() };
+    let info = FlushJobInfo {
+        inner: info,
+        table_properties: NonNull::new(table_properties).unwrap(),
+    };
     ctx.on_flush_completed(&info);
 }
 

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -4,7 +4,7 @@ use std::ptr::NonNull;
 use libc::{c_char, c_void};
 
 use crate::ffi_util::convert_rocksdb_error;
-use crate::{ffi, CStrLike, Error};
+use crate::{CStrLike, Error, ffi};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(C)]
@@ -292,7 +292,7 @@ impl FlushJobInfo {
             let keys_ptr = ffi::rocksdb_table_properties_get_user_collected_property_keys(
                 self.table_properties.as_ptr(),
                 prefix.as_ptr(),
-                &mut key_count,
+                &raw mut key_count,
             );
 
             if keys_ptr.is_null() {
@@ -582,7 +582,7 @@ extern "C" fn destructor<E: EventListener>(ctx: *mut c_void) {
     }
 }
 
-unsafe extern "C" fn on_flush_begin<E: EventListener>(
+extern "C" fn on_flush_begin<E: EventListener>(
     ctx: *mut c_void,
     _: *mut ffi::rocksdb_t,
     info: *const ffi::rocksdb_flushjobinfo_t,

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -3,7 +3,7 @@ use std::ptr::NonNull;
 
 use libc::{c_char, c_void};
 
-use crate::ffi_util::{convert_rocksdb_error, error_message};
+use crate::ffi_util::convert_rocksdb_error;
 use crate::{ffi, CStrLike, Error};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,9 @@ pub use crate::{
     },
     compaction_filter::Decision as CompactionDecision,
     db::{
-        DB, DBAccess, DBCommon, DBWithThreadMode, ExportImportFilesMetaData, LiveFile,
-        MultiThreaded, PrefixProber, Range, SingleThreaded, ThreadMode,
+        ColumnFamilyMetaDataRef, DB, DBAccess, DBCommon, DBWithThreadMode,
+        ExportImportFilesMetaData, LevelMetaDataRef, LiveFile, MultiThreaded, PrefixProber, Range,
+        SingleThreaded, SstFileMetaDataRef, ThreadMode,
     },
     db_iterator::{
         DBIterator, DBIteratorWithThreadMode, DBRawIterator, DBRawIteratorWithThreadMode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ mod snapshot;
 pub mod sst_file_manager;
 mod sst_file_writer;
 pub mod statistics;
+pub mod table_properties;
 mod transactions;
 mod write_batch;
 mod write_batch_with_index;

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -1,0 +1,264 @@
+use std::ffi::{c_char, c_void, CStr, CString};
+use std::marker::PhantomData;
+use std::mem;
+use std::slice;
+
+use libc::{c_int, size_t};
+
+use crate::{ffi, Options};
+
+/// Extension trait for [`Options`] to register table properties collectors
+pub trait TablePropertiesExt {
+    fn add_table_properties_collector_factory<F>(&mut self, factory: F)
+    where
+        F: TablePropertiesCollectorFactory + Send + 'static;
+}
+
+impl TablePropertiesExt for Options {
+    fn add_table_properties_collector_factory<F>(&mut self, factory: F)
+    where
+        F: TablePropertiesCollectorFactory + Send + 'static,
+    {
+        unsafe {
+            let factory_ptr = Box::into_raw(Box::new(factory)) as *mut c_void;
+
+            // Takes ownership of the collector factory; the Rust callback wrapper will be
+            // dropped via the destructor callback
+            ffi::rocksdb_options_add_table_properties_collector_factory(
+                self.inner,
+                factory_ptr,
+                Some(TablePropertiesCollectorFactoryCallback::<F>::destructor),
+                Some(TablePropertiesCollectorFactoryCallback::<F>::name),
+                Some(TablePropertiesCollectorFactoryCallback::<F>::create_collector),
+            );
+        }
+    }
+}
+
+#[repr(C)]
+pub enum EntryType {
+    EntryPut,
+    EntryDelete,
+    EntrySingleDelete,
+    EntryMerge,
+    EntryRangeDeletion,
+    EntryBlobIndex,
+    EntryDeleteWithTimestamp,
+    EntryWideColumnEntity,
+    EntryTimedPut,
+    EntryOther,
+}
+
+pub struct TablePropertiesCollectorContext {
+    pub column_family_id: u32,
+    pub level_at_creation: i32,
+    pub num_levels: i32,
+    pub last_level_inclusive_max_seqno_threshold: u64,
+}
+
+/// Table properties collector factory trait
+pub trait TablePropertiesCollectorFactory {
+    type Collector: TablePropertiesCollector;
+
+    /// Create a new table properties collector
+    fn create(&mut self, context: TablePropertiesCollectorContext) -> Self::Collector;
+
+    /// Name of the collector factory to use for logging
+    fn name(&self) -> &CStr;
+}
+
+/// Table properties collector trait
+pub trait TablePropertiesCollector {
+    /// Called when a new key/value pair is added to the table
+    ///
+    /// Returning `Err` will cause an error to be logged but otherwise continue building the
+    /// table as normal.
+    fn add_user_key(
+        &mut self,
+        key: &[u8],
+        value: &[u8],
+        entry_type: EntryType,
+        seq: u64,
+        file_size: u64,
+    ) -> Result<(), CollectorError>;
+
+    /// Called after each new block is cut
+    fn block_add(
+        &mut self,
+        _block_uncompressed_bytes: u64,
+        _block_compressed_bytes_fast: u64,
+        _block_compressed_bytes_slow: u64,
+    ) {
+    }
+
+    /// Called once when a table has been built and is ready for writing the properties block
+    ///
+    /// When the result is `Err`, the collected properties will not be written to the file's
+    /// property block.
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, CollectorError>;
+
+    /// Returns human-readable properties used for logging
+    ///
+    /// This method will be called after finish() has been called.
+    fn get_readable_properties(&self) -> impl IntoIterator<Item = &(CString, CString)>;
+
+    /// Name of the collector to use for logging
+    fn name(&self) -> &CStr;
+}
+
+/// Collector error
+///
+/// This error is not meaningfully used by RocksDB, other than to indicate an unsuccessful callback.
+/// It intentionally does not accept a message or other detail as these would be ignored downstream.
+#[derive(Debug, Default)]
+pub struct CollectorError {
+    _private: (),
+}
+
+impl std::fmt::Display for CollectorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Property collector error")
+    }
+}
+
+struct TablePropertiesCollectorFactoryCallback<F>
+where
+    F: TablePropertiesCollectorFactory + Send + 'static,
+{
+    _phantom: PhantomData<F>,
+}
+
+impl<F> TablePropertiesCollectorFactoryCallback<F>
+where
+    F: TablePropertiesCollectorFactory + Send + 'static,
+{
+    unsafe extern "C" fn create_collector(
+        raw_self: *mut c_void,
+        ctx: *mut ffi::rocksdb_table_properties_collector_context_t,
+    ) -> *mut ffi::rocksdb_table_properties_collector_t {
+        let context = TablePropertiesCollectorContext {
+                column_family_id: ffi::rocksdb_table_properties_collector_context_get_column_family_id(ctx),
+                level_at_creation: ffi::rocksdb_table_properties_collector_context_get_level_at_creation(ctx),
+                num_levels: ffi::rocksdb_table_properties_collector_context_get_num_levels(ctx),
+                last_level_inclusive_max_seqno_threshold:
+                    ffi::rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_threshold(ctx),
+            };
+
+        let factory: &mut F = &mut *(raw_self.cast());
+        let collector = Box::new(factory.create(context));
+
+        ffi::rocksdb_table_properties_collector_create(
+            Box::into_raw(collector).cast(),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::destructor),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::add_user_key),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::block_add),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::finish),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::get_readable_properties),
+            Some(TablePropertiesCollectorCallback::<F::Collector>::name),
+        )
+    }
+
+    unsafe extern "C" fn name(raw_self: *mut c_void) -> *const c_char {
+        let factory = &*(raw_self.cast_const() as *const F);
+        factory.name().as_ptr()
+    }
+
+    unsafe extern "C" fn destructor(raw_self: *mut c_void) {
+        drop(Box::from_raw(raw_self as *mut F));
+    }
+}
+
+struct TablePropertiesCollectorCallback<C>
+where
+    C: TablePropertiesCollector,
+{
+    _marker: PhantomData<C>,
+}
+
+impl<C> TablePropertiesCollectorCallback<C>
+where
+    C: TablePropertiesCollector,
+{
+    unsafe extern "C" fn destructor(raw_collector: *mut c_void) {
+        drop(Box::from_raw(raw_collector as *mut C));
+    }
+
+    unsafe extern "C" fn name(raw_collector: *mut c_void) -> *const c_char {
+        let collector: &mut C = &mut *(raw_collector.cast());
+        collector.name().as_ptr()
+    }
+
+    unsafe extern "C" fn add_user_key(
+        raw_collector: *mut c_void,
+        key_ptr: *const c_char,
+        key_len: size_t,
+        value_ptr: *const c_char,
+        value_len: size_t,
+        entry_type: c_int,
+        seq: u64,
+        file_size: u64,
+    ) -> bool {
+        let collector: &mut C = &mut *(raw_collector.cast());
+
+        let key = slice::from_raw_parts(key_ptr as *const u8, key_len);
+        let value = slice::from_raw_parts(value_ptr as *const u8, value_len);
+        let entry_type = mem::transmute::<c_int, EntryType>(entry_type);
+
+        collector
+            .add_user_key(key, value, entry_type, seq, file_size)
+            .is_ok()
+    }
+
+    unsafe extern "C" fn block_add(
+        raw_collector: *mut c_void,
+        block_uncompressed_bytes: u64,
+        block_compressed_bytes_fast: u64,
+        block_compressed_bytes_slow: u64,
+    ) {
+        let collector: &mut C = &mut *(raw_collector.cast());
+        collector.block_add(
+            block_uncompressed_bytes,
+            block_compressed_bytes_fast,
+            block_compressed_bytes_slow,
+        );
+    }
+
+    unsafe extern "C" fn finish(
+        raw_collector: *mut c_void,
+        user_collected_properties: *mut ffi::rocksdb_user_collected_properties_t,
+    ) -> bool {
+        let collector: &mut C = &mut *(raw_collector.cast());
+
+        let Ok(props) = collector.finish() else {
+            // An error will be logged by RocksDB to its own log, though the details will be swallowed.
+            // Property collectors should perform their own logging via other mechanisms if required.
+            return false;
+        };
+
+        for (key, value) in props {
+            ffi::rocksdb_user_collected_properties_insert(
+                user_collected_properties,
+                key.as_ref().as_ptr(),
+                value.as_ref().as_ptr(),
+            );
+        }
+
+        true
+    }
+
+    unsafe extern "C" fn get_readable_properties(
+        raw_collector: *mut c_void,
+        user_collected_properties: *mut ffi::rocksdb_user_collected_properties_t,
+    ) {
+        let collector: &mut C = &mut *(raw_collector.cast());
+        let props = collector.get_readable_properties();
+
+        for (key, value) in props {
+            ffi::rocksdb_user_collected_properties_insert(
+                user_collected_properties,
+                key.as_ref().as_ptr(),
+                value.as_ref().as_ptr(),
+            );
+        }
+    }
+}

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -104,6 +104,11 @@ pub trait TablePropertiesCollector {
 
     /// Name of the collector to use for logging
     fn name(&self) -> &CStr;
+
+    /// Returns whether the output file should be further compacted
+    fn need_compact(&self) -> bool {
+        false
+    }
 }
 
 /// Collector error
@@ -161,6 +166,7 @@ where
                 Some(TablePropertiesCollectorCallback::<F::Collector>::finish),
                 Some(TablePropertiesCollectorCallback::<F::Collector>::get_readable_properties),
                 Some(TablePropertiesCollectorCallback::<F::Collector>::name),
+                Some(TablePropertiesCollectorCallback::<F::Collector>::need_compact),
             )
         }
     }
@@ -283,5 +289,11 @@ where
                 );
             }
         }
+    }
+
+    unsafe extern "C" fn need_compact(raw_collector: *mut c_void) -> bool {
+        // SAFETY: raw_collector is a valid pointer to C created in create_collector
+        let collector: &C = unsafe { &*(raw_collector.cast_const() as *const C) };
+        collector.need_compact()
     }
 }

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -1,11 +1,11 @@
-use std::ffi::{c_char, c_void, CStr, CString};
+use std::ffi::{CStr, CString, c_char, c_void};
 use std::marker::PhantomData;
 use std::mem;
 use std::slice;
 
 use libc::{c_int, size_t};
 
-use crate::{ffi, Options};
+use crate::{Options, ffi};
 
 /// Extension trait for [`Options`] to register table properties collectors
 pub trait TablePropertiesExt {
@@ -136,35 +136,44 @@ where
         raw_self: *mut c_void,
         ctx: *mut ffi::rocksdb_table_properties_collector_context_t,
     ) -> *mut ffi::rocksdb_table_properties_collector_t {
-        let context = TablePropertiesCollectorContext {
+        // SAFETY: ctx is a valid pointer provided by RocksDB
+        let context = unsafe {
+            TablePropertiesCollectorContext {
                 column_family_id: ffi::rocksdb_table_properties_collector_context_get_column_family_id(ctx),
                 level_at_creation: ffi::rocksdb_table_properties_collector_context_get_level_at_creation(ctx),
                 num_levels: ffi::rocksdb_table_properties_collector_context_get_num_levels(ctx),
                 last_level_inclusive_max_seqno_threshold:
                     ffi::rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_threshold(ctx),
-            };
+            }
+        };
 
-        let factory: &mut F = &mut *(raw_self.cast());
+        // SAFETY: raw_self is a valid pointer to F created in add_table_properties_collector_factory
+        let factory: &mut F = unsafe { &mut *(raw_self.cast()) };
         let collector = Box::new(factory.create(context));
 
-        ffi::rocksdb_table_properties_collector_create(
-            Box::into_raw(collector).cast(),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::destructor),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::add_user_key),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::block_add),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::finish),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::get_readable_properties),
-            Some(TablePropertiesCollectorCallback::<F::Collector>::name),
-        )
+        // SAFETY: FFI call with valid pointers
+        unsafe {
+            ffi::rocksdb_table_properties_collector_create(
+                Box::into_raw(collector).cast(),
+                Some(TablePropertiesCollectorCallback::<F::Collector>::destructor),
+                Some(TablePropertiesCollectorCallback::<F::Collector>::add_user_key),
+                Some(TablePropertiesCollectorCallback::<F::Collector>::block_add),
+                Some(TablePropertiesCollectorCallback::<F::Collector>::finish),
+                Some(TablePropertiesCollectorCallback::<F::Collector>::get_readable_properties),
+                Some(TablePropertiesCollectorCallback::<F::Collector>::name),
+            )
+        }
     }
 
     unsafe extern "C" fn name(raw_self: *mut c_void) -> *const c_char {
-        let factory = &*(raw_self.cast_const() as *const F);
+        // SAFETY: raw_self is a valid pointer to F created in add_table_properties_collector_factory
+        let factory = unsafe { &*(raw_self.cast_const() as *const F) };
         factory.name().as_ptr()
     }
 
     unsafe extern "C" fn destructor(raw_self: *mut c_void) {
-        drop(Box::from_raw(raw_self as *mut F));
+        // SAFETY: raw_self is a valid pointer to F created in add_table_properties_collector_factory
+        drop(unsafe { Box::from_raw(raw_self as *mut F) });
     }
 }
 
@@ -180,11 +189,13 @@ where
     C: TablePropertiesCollector,
 {
     unsafe extern "C" fn destructor(raw_collector: *mut c_void) {
-        drop(Box::from_raw(raw_collector as *mut C));
+        // SAFETY: raw_collector is a valid pointer to C created in create_collector
+        drop(unsafe { Box::from_raw(raw_collector as *mut C) });
     }
 
     unsafe extern "C" fn name(raw_collector: *mut c_void) -> *const c_char {
-        let collector: &mut C = &mut *(raw_collector.cast());
+        // SAFETY: raw_collector is a valid pointer to C created in create_collector
+        let collector: &mut C = unsafe { &mut *(raw_collector.cast()) };
         collector.name().as_ptr()
     }
 
@@ -198,11 +209,14 @@ where
         seq: u64,
         file_size: u64,
     ) -> bool {
-        let collector: &mut C = &mut *(raw_collector.cast());
+        // SAFETY: raw_collector is a valid pointer to C created in create_collector
+        let collector: &mut C = unsafe { &mut *(raw_collector.cast()) };
 
-        let key = slice::from_raw_parts(key_ptr as *const u8, key_len);
-        let value = slice::from_raw_parts(value_ptr as *const u8, value_len);
-        let entry_type = mem::transmute::<c_int, EntryType>(entry_type);
+        // SAFETY: key_ptr and value_ptr are valid pointers provided by RocksDB with correct lengths
+        let key = unsafe { slice::from_raw_parts(key_ptr as *const u8, key_len) };
+        let value = unsafe { slice::from_raw_parts(value_ptr as *const u8, value_len) };
+        // SAFETY: entry_type is a valid EntryType value from RocksDB
+        let entry_type = unsafe { mem::transmute::<c_int, EntryType>(entry_type) };
 
         collector
             .add_user_key(key, value, entry_type, seq, file_size)
@@ -215,7 +229,8 @@ where
         block_compressed_bytes_fast: u64,
         block_compressed_bytes_slow: u64,
     ) {
-        let collector: &mut C = &mut *(raw_collector.cast());
+        // SAFETY: raw_collector is a valid pointer to C created in create_collector
+        let collector: &mut C = unsafe { &mut *(raw_collector.cast()) };
         collector.block_add(
             block_uncompressed_bytes,
             block_compressed_bytes_fast,
@@ -227,7 +242,8 @@ where
         raw_collector: *mut c_void,
         user_collected_properties: *mut ffi::rocksdb_user_collected_properties_t,
     ) -> bool {
-        let collector: &mut C = &mut *(raw_collector.cast());
+        // SAFETY: raw_collector is a valid pointer to C created in create_collector
+        let collector: &mut C = unsafe { &mut *(raw_collector.cast()) };
 
         let Ok(props) = collector.finish() else {
             // An error will be logged by RocksDB to its own log, though the details will be swallowed.
@@ -236,11 +252,14 @@ where
         };
 
         for (key, value) in props {
-            ffi::rocksdb_user_collected_properties_insert(
-                user_collected_properties,
-                key.as_ref().as_ptr(),
-                value.as_ref().as_ptr(),
-            );
+            // SAFETY: user_collected_properties is a valid pointer provided by RocksDB
+            unsafe {
+                ffi::rocksdb_user_collected_properties_insert(
+                    user_collected_properties,
+                    key.as_ref().as_ptr(),
+                    value.as_ref().as_ptr(),
+                );
+            }
         }
 
         true
@@ -250,15 +269,19 @@ where
         raw_collector: *mut c_void,
         user_collected_properties: *mut ffi::rocksdb_user_collected_properties_t,
     ) {
-        let collector: &mut C = &mut *(raw_collector.cast());
+        // SAFETY: raw_collector is a valid pointer to C created in create_collector
+        let collector: &mut C = unsafe { &mut *(raw_collector.cast()) };
         let props = collector.get_readable_properties();
 
         for (key, value) in props {
-            ffi::rocksdb_user_collected_properties_insert(
-                user_collected_properties,
-                key.as_ref().as_ptr(),
-                value.as_ref().as_ptr(),
-            );
+            // SAFETY: user_collected_properties is a valid pointer provided by RocksDB
+            unsafe {
+                ffi::rocksdb_user_collected_properties_insert(
+                    user_collected_properties,
+                    key.as_ref().as_ptr(),
+                    value.as_ref().as_ptr(),
+                );
+            }
         }
     }
 }

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -297,3 +297,31 @@ where
         collector.need_compact()
     }
 }
+
+/// Borrowed reference to a table's properties, valid for the duration of a filter callback.
+///
+/// Provides access to user-collected properties set by a [`TablePropertiesCollector`].
+pub struct TableProperties {
+    raw: *const ffi::rocksdb_table_properties_t,
+}
+
+impl TableProperties {
+    /// Wraps a raw pointer for the duration of a callback. The caller must ensure
+    /// the pointer remains valid for the lifetime of the returned value.
+    pub(crate) unsafe fn from_raw(raw: *const ffi::rocksdb_table_properties_t) -> Self {
+        Self { raw }
+    }
+
+    /// Returns the value of a user-collected property by key, or `None` if it doesn't exist.
+    pub fn get_user_collected_property(&self, key: &CStr) -> Option<&CStr> {
+        unsafe {
+            let val =
+                ffi::rocksdb_table_properties_get_user_collected_property(self.raw, key.as_ptr());
+            if val.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(val))
+            }
+        }
+    }
+}

--- a/src/transactions/optimistic_transaction_db.rs
+++ b/src/transactions/optimistic_transaction_db.rs
@@ -200,7 +200,7 @@ impl<T: ThreadMode> OptimisticTransactionDB<T> {
             }
 
             for (cf_desc, inner) in cfs_v.iter().zip(cfhandles) {
-                cf_map.insert(cf_desc.name.clone(), inner);
+                cf_map.insert(cf_desc.name.clone().into(), inner);
             }
         }
 

--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -310,7 +310,7 @@ impl<T: ThreadMode> TransactionDB<T> {
             }
 
             for (cf_desc, inner) in cfs_v.iter().zip(cfhandles) {
-                cf_map.insert(cf_desc.name.clone(), inner);
+                cf_map.insert(cf_desc.name.clone().into(), inner);
             }
         }
 
@@ -1001,7 +1001,7 @@ impl TransactionDB<SingleThreaded> {
         let inner = self.create_inner_cf_handle(name.as_ref(), opts)?;
         self.cfs
             .cfs
-            .insert(name.as_ref().to_string(), ColumnFamily { inner });
+            .insert(name.as_ref().into(), ColumnFamily { inner });
         Ok(())
     }
 
@@ -1027,7 +1027,7 @@ impl TransactionDB<MultiThreaded> {
         let mut cfs = self.cfs.cfs.write();
         let inner = self.create_inner_cf_handle(name.as_ref(), opts)?;
         cfs.insert(
-            name.as_ref().to_string(),
+            name.as_ref().into(),
             Arc::new(UnboundColumnFamily { inner }),
         );
         Ok(())

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{AsColumnFamilyRef, ffi};
+use crate::{AsColumnFamilyRef, ffi, Error};
 use libc::{c_char, c_void, size_t};
 use smallvec::SmallVec;
 use std::io::IoSlice;
@@ -348,6 +348,29 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
                 value_ptrs.as_ptr(),
                 value_lens.as_ptr(),
             );
+        }
+    }
+
+    /// Record the state of the operations for future calls to [`rollback_to_savepoint`].
+    /// May be called multiple times to set multiple save points.
+    ///
+    /// [`rollback_to_savepoint`]: Self::rollback_to_savepoint
+    pub fn set_savepoint(&mut self) {
+        unsafe {
+            ffi::rocksdb_writebatch_set_save_point(self.inner);
+        }
+    }
+
+    /// Undo all operations in this batch since the most recent call to [`set_savepoint`]
+    /// and removes the most recent [`set_savepoint`].
+    ///
+    /// Returns error if there is no previous call to [`set_savepoint`].
+    ///
+    /// [`set_savepoint`]: Self::set_savepoint
+    pub fn rollback_to_savepoint(&mut self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_writebatch_rollback_to_save_point(self.inner));
+            Ok(())
         }
     }
 

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{AsColumnFamilyRef, ffi, Error};
+use crate::{AsColumnFamilyRef, Error, ffi};
 use libc::{c_char, c_void, size_t};
 use smallvec::SmallVec;
 use std::io::IoSlice;

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -14,6 +14,8 @@
 
 use crate::{AsColumnFamilyRef, ffi};
 use libc::{c_char, c_void, size_t};
+use smallvec::SmallVec;
+use std::io::IoSlice;
 use std::slice;
 
 /// A type alias to keep compatibility. See [`WriteBatchWithTransaction`] for details
@@ -293,6 +295,62 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
         }
     }
 
+    /// Insert a value into the database using vectored I/O from multiple memory segments.
+    /// Avoids user-side copying when data spans multiple slices, though RocksDB still copies internally.
+    pub fn put_vectored(&mut self, key: &[IoSlice<'_>], value: &[IoSlice<'_>]) {
+        const INLINE: usize = 16;
+        let key_ptrs: SmallVec<[*const c_char; INLINE]> =
+            key.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let key_lens: SmallVec<[size_t; INLINE]> = key.iter().map(|s| s.len()).collect();
+
+        let value_ptrs: SmallVec<[*const c_char; INLINE]> =
+            value.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let value_lens: SmallVec<[size_t; INLINE]> = value.iter().map(|s| s.len()).collect();
+
+        unsafe {
+            ffi::rocksdb_writebatch_putv(
+                self.inner,
+                key.len() as libc::c_int,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                value.len() as libc::c_int,
+                value_ptrs.as_ptr(),
+                value_lens.as_ptr(),
+            );
+        }
+    }
+
+    /// Insert a value into a column family using vectored I/O from multiple memory segments.
+    /// Avoids user-side copying when data spans multiple slices, though RocksDB still copies internally.
+    pub fn put_cf_vectored(
+        &mut self,
+        cf: &impl AsColumnFamilyRef,
+        key: &[IoSlice<'_>],
+        value: &[IoSlice<'_>],
+    ) {
+        const INLINE: usize = 16;
+        let key_ptrs: SmallVec<[*const c_char; INLINE]> =
+            key.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let key_lens: SmallVec<[size_t; INLINE]> = key.iter().map(|s| s.len()).collect();
+
+        let value_ptrs: SmallVec<[*const c_char; INLINE]> =
+            value.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let value_lens: SmallVec<[size_t; INLINE]> = value.iter().map(|s| s.len()).collect();
+
+        unsafe {
+            ffi::rocksdb_writebatch_putv_cf(
+                self.inner,
+                cf.inner(),
+                key.len() as libc::c_int,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                value.len() as libc::c_int,
+                value_ptrs.as_ptr(),
+                value_lens.as_ptr(),
+            );
+        }
+    }
+
     /// Insert a value into the specific column family of the database
     /// under the given key with timestamp.
     pub fn put_cf_with_ts<K, V, S>(&mut self, cf: &impl AsColumnFamilyRef, key: K, ts: S, value: V)
@@ -337,6 +395,31 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
         }
     }
 
+    /// Merge a value into the database using vectored I/O from multiple memory segments.
+    /// Avoids user-side copying when data spans multiple slices, though RocksDB still copies internally.
+    pub fn merge_vectored(&mut self, key: &[IoSlice<'_>], value: &[IoSlice<'_>]) {
+        const INLINE: usize = 16;
+        let key_ptrs: SmallVec<[*const c_char; INLINE]> =
+            key.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let key_lens: SmallVec<[size_t; INLINE]> = key.iter().map(|s| s.len()).collect();
+
+        let value_ptrs: SmallVec<[*const c_char; INLINE]> =
+            value.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let value_lens: SmallVec<[size_t; INLINE]> = value.iter().map(|s| s.len()).collect();
+
+        unsafe {
+            ffi::rocksdb_writebatch_mergev(
+                self.inner,
+                key.len() as libc::c_int,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                value.len() as libc::c_int,
+                value_ptrs.as_ptr(),
+                value_lens.as_ptr(),
+            );
+        }
+    }
+
     pub fn merge_cf<K, V>(&mut self, cf: &impl AsColumnFamilyRef, key: K, value: V)
     where
         K: AsRef<[u8]>,
@@ -353,6 +436,37 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
                 key.len() as size_t,
                 value.as_ptr() as *const c_char,
                 value.len() as size_t,
+            );
+        }
+    }
+
+    /// Merge a value into a column family using vectored I/O from multiple memory segments.
+    /// Avoids user-side copying when data spans multiple slices, though RocksDB still copies internally.
+    pub fn merge_cf_vectored(
+        &mut self,
+        cf: &impl AsColumnFamilyRef,
+        key: &[IoSlice<'_>],
+        value: &[IoSlice<'_>],
+    ) {
+        const INLINE: usize = 16;
+        let key_ptrs: SmallVec<[*const c_char; INLINE]> =
+            key.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let key_lens: SmallVec<[size_t; INLINE]> = key.iter().map(|s| s.len()).collect();
+
+        let value_ptrs: SmallVec<[*const c_char; INLINE]> =
+            value.iter().map(|s| s.as_ptr() as *const c_char).collect();
+        let value_lens: SmallVec<[size_t; INLINE]> = value.iter().map(|s| s.len()).collect();
+
+        unsafe {
+            ffi::rocksdb_writebatch_mergev_cf(
+                self.inner,
+                cf.inner(),
+                key.len() as libc::c_int,
+                key_ptrs.as_ptr(),
+                key_lens.as_ptr(),
+                value.len() as libc::c_int,
+                value_ptrs.as_ptr(),
+                value_lens.as_ptr(),
             );
         }
     }

--- a/src/write_batch_with_index.rs
+++ b/src/write_batch_with_index.rs
@@ -34,6 +34,31 @@ impl WriteBatchWithIndex {
         }
     }
 
+    /// Record the state of the operations for future calls to [`rollback_to_savepoint`].
+    /// May be called multiple times to set multiple save points.
+    ///
+    /// [`rollback_to_savepoint`]: Self::rollback_to_savepoint
+    pub fn set_savepoint(&mut self) {
+        unsafe {
+            ffi::rocksdb_writebatch_wi_set_save_point(self.inner);
+        }
+    }
+
+    /// Undo all operations in this batch since the most recent call to [`set_savepoint`]
+    /// and removes the most recent [`set_savepoint`].
+    ///
+    /// Returns error if there is no previous call to [`set_savepoint`].
+    ///
+    /// [`set_savepoint`]: Self::set_savepoint
+    pub fn rollback_to_savepoint(&mut self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_writebatch_wi_rollback_to_save_point(
+                self.inner
+            ));
+            Ok(())
+        }
+    }
+
     /// Return a reference to a byte array which represents a serialized version of the batch.
     pub fn data(&self) -> &[u8] {
         unsafe {

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -440,12 +440,61 @@ fn set_column_family_metadata_test() {
         db.flush_cf(&cf2).unwrap();
 
         let default_cf_metadata = db.get_column_family_metadata();
-        assert_eq!(default_cf_metadata.size > 150, true);
-        assert_eq!(default_cf_metadata.file_count, 1);
+        let default_cf_size = default_cf_metadata.size();
+        assert!(default_cf_size > 150);
+        assert_eq!(default_cf_metadata.file_count(), 1);
+        assert_eq!(default_cf_metadata.name(), DEFAULT_COLUMN_FAMILY_NAME);
+
+        // Verify level metadata using lazy accessors
+        assert!(default_cf_metadata.level_count() > 0);
+
+        // After flush, data should be in L0 (level 0)
+        // Calculate total size from levels
+        let total_level_size: u64 = default_cf_metadata.levels().map(|l| l.size()).sum();
+        assert_eq!(default_cf_size, total_level_size);
+
+        // Find the level with files (should be L0 after flush)
+        let levels_with_files_count = default_cf_metadata
+            .levels()
+            .filter(|l| l.file_count() > 0)
+            .count();
+        assert!(levels_with_files_count > 0);
+
+        // Verify SST file metadata using lazy accessors
+        for level in default_cf_metadata.levels() {
+            for file in level.files() {
+                assert!(!file.relative_filename().is_empty());
+                assert!(!file.directory().is_empty());
+                assert!(file.size() > 0);
+                // After flush, files should have keys
+                assert!(file.smallest_key().is_some());
+                assert!(file.largest_key().is_some());
+            }
+        }
 
         let cf2_metadata = db.get_column_family_metadata_cf(&cf2);
-        assert_eq!(cf2_metadata.size > default_cf_metadata.size, true);
-        assert_eq!(cf2_metadata.file_count, 1);
+        assert!(cf2_metadata.size() > default_cf_size);
+        assert_eq!(cf2_metadata.file_count(), 1);
+        assert_eq!(cf2_metadata.name(), "cf2");
+
+        // Verify cf2 level metadata
+        assert!(cf2_metadata.level_count() > 0);
+        let cf2_total_level_size: u64 = cf2_metadata.levels().map(|l| l.size()).sum();
+        assert_eq!(cf2_metadata.size(), cf2_total_level_size);
+
+        // Verify cf2 has files with expected keys
+        // Find a level with files and check the first file
+        let mut found_file = false;
+        for level in cf2_metadata.levels() {
+            if let Some(file) = level.file(0) {
+                // cf2 should have keys key1, key2, key3 so smallest should be key1 and largest key3
+                assert_eq!(file.smallest_key().as_deref(), Some(b"key1".as_slice()));
+                assert_eq!(file.largest_key().as_deref(), Some(b"key3".as_slice()));
+                found_file = true;
+                break;
+            }
+        }
+        assert!(found_file, "cf2 should have at least one file");
     }
 }
 

--- a/tests/test_table_filter.rs
+++ b/tests/test_table_filter.rs
@@ -1,0 +1,137 @@
+mod util;
+
+use std::ffi::{CStr, CString};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use rust_rocksdb::table_properties::{
+    CollectorError, EntryType, TableProperties, TablePropertiesCollector,
+    TablePropertiesCollectorContext, TablePropertiesCollectorFactory, TablePropertiesExt,
+};
+use rust_rocksdb::{DB, IteratorMode, Options, ReadOptions};
+use util::DBPath;
+
+/// Counts Put entries and stores the count as a user-collected property "entry_count".
+struct EntryCountCollectorFactory;
+
+impl TablePropertiesCollectorFactory for EntryCountCollectorFactory {
+    type Collector = EntryCountCollector;
+
+    fn create(&mut self, _context: TablePropertiesCollectorContext) -> Self::Collector {
+        EntryCountCollector {
+            count: 0,
+            props: vec![],
+        }
+    }
+
+    fn name(&self) -> &CStr {
+        c"EntryCountCollectorFactory"
+    }
+}
+
+struct EntryCountCollector {
+    count: u32,
+    props: Vec<(CString, CString)>,
+}
+
+impl TablePropertiesCollector for EntryCountCollector {
+    fn add_user_key(
+        &mut self,
+        _key: &[u8],
+        _value: &[u8],
+        entry_type: EntryType,
+        _seq: u64,
+        _file_size: u64,
+    ) -> Result<(), CollectorError> {
+        if let EntryType::EntryPut = entry_type {
+            self.count += 1;
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, CollectorError> {
+        self.props.push((
+            c"entry_count".to_owned(),
+            CString::new(self.count.to_string()).unwrap(),
+        ));
+        Ok(self.props.iter())
+    }
+
+    fn get_readable_properties(&self) -> impl IntoIterator<Item = &(CString, CString)> {
+        self.props.iter()
+    }
+
+    fn name(&self) -> &CStr {
+        c"EntryCountCollector"
+    }
+}
+
+#[test]
+fn test_table_filter_skips_sst() {
+    let path = DBPath::new("_rust_rocksdb_table_filter_test");
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.add_table_properties_collector_factory(EntryCountCollectorFactory);
+    // Disable auto-compaction so our 3 SSTs stay separate
+    opts.set_disable_auto_compactions(true);
+
+    let db = DB::open(&opts, &path).unwrap();
+
+    // SST 1: 1 entry (key "a")
+    db.put(b"a", b"val_a").unwrap();
+    db.flush().unwrap();
+
+    // SST 2: 2 entries (keys "b", "c")
+    db.put(b"b", b"val_b").unwrap();
+    db.put(b"c", b"val_c").unwrap();
+    db.flush().unwrap();
+
+    // SST 3: 3 entries (keys "d", "e", "f")
+    db.put(b"d", b"val_d").unwrap();
+    db.put(b"e", b"val_e").unwrap();
+    db.put(b"f", b"val_f").unwrap();
+    db.flush().unwrap();
+
+    // Without filter: all 6 keys
+    let all_keys: Vec<_> = db
+        .iterator(IteratorMode::Start)
+        .map(|r| r.unwrap().0.to_vec())
+        .collect();
+    assert_eq!(
+        all_keys,
+        vec![
+            b"a".to_vec(),
+            b"b".to_vec(),
+            b"c".to_vec(),
+            b"d".to_vec(),
+            b"e".to_vec(),
+            b"f".to_vec()
+        ]
+    );
+
+    // With filter: skip SSTs that have entry_count == "2"
+    let mut read_opts = ReadOptions::default();
+    let filter_call_count = Arc::new(AtomicU32::new(0));
+    let counter = Arc::clone(&filter_call_count);
+    read_opts.set_table_filter(move |props: &TableProperties| {
+        counter.fetch_add(1, Ordering::Relaxed);
+        let count = props.get_user_collected_property(c"entry_count");
+        // Keep tables where entry_count != "2"
+        count != Some(c"2")
+    });
+
+    let filtered_keys: Vec<_> = db
+        .iterator_opt(IteratorMode::Start, read_opts)
+        .map(|r| r.unwrap().0.to_vec())
+        .collect();
+
+    // SST 2 (keys b, c) should be skipped
+    assert_eq!(
+        filtered_keys,
+        vec![b"a".to_vec(), b"d".to_vec(), b"e".to_vec(), b"f".to_vec()]
+    );
+
+    // The filter should have been called once per SST (3 times)
+    assert_eq!(filter_call_count.load(Ordering::Relaxed), 3);
+}

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -2,7 +2,7 @@ mod util;
 
 use std::ffi::{CStr, CString};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use parking_lot::RwLock;
 
@@ -188,5 +188,105 @@ impl EventListener for CustomPropertyListener {
                 .map(|&cstr| cstr.to_owned())
                 .collect(),
         );
+    }
+}
+
+#[test]
+fn test_table_properties_collector_need_compact() {
+    let path = DBPath::new("_rust_rocksdb_properties_collector_need_compact_test");
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+
+    let mut cf_opts = Options::default();
+    let returned_need_compact = Arc::new(AtomicBool::new(false));
+    let collector_factory = NeedCompactCollectorFactory {
+        returned_need_compact: Arc::clone(&returned_need_compact),
+    };
+    cf_opts.add_table_properties_collector_factory(collector_factory);
+
+    let db = DB::open_cf_with_opts(&opts, &path, [("cf", cf_opts)]).unwrap();
+
+    let cf = db.cf_handle("cf").unwrap();
+
+    // Write keys that don't trigger need_compact
+    db.put_cf(&cf, b"normal_key", b"value").unwrap();
+    db.flush_cf(&cf).unwrap();
+
+    // need_compact should have returned false (no keys starting with "compact")
+    assert!(
+        !returned_need_compact.load(Ordering::Relaxed),
+        "need_compact should have returned false"
+    );
+
+    // Write a key that triggers need_compact to return true
+    db.put_cf(&cf, b"compact_me", b"value").unwrap();
+    db.flush_cf(&cf).unwrap();
+
+    // need_compact should have returned true this time
+    assert!(
+        returned_need_compact.load(Ordering::Relaxed),
+        "need_compact should have returned true"
+    );
+}
+
+struct NeedCompactCollectorFactory {
+    returned_need_compact: Arc<AtomicBool>,
+}
+
+impl TablePropertiesCollectorFactory for NeedCompactCollectorFactory {
+    type Collector = NeedCompactCollector;
+
+    fn create(&mut self, _context: TablePropertiesCollectorContext) -> Self::Collector {
+        NeedCompactCollector {
+            returned_need_compact: Arc::clone(&self.returned_need_compact),
+            should_compact: false,
+        }
+    }
+
+    fn name(&self) -> &CStr {
+        c"NeedCompactCollectorFactory"
+    }
+}
+
+struct NeedCompactCollector {
+    returned_need_compact: Arc<AtomicBool>,
+    should_compact: bool,
+}
+
+impl TablePropertiesCollector for NeedCompactCollector {
+    fn add_user_key(
+        &mut self,
+        key: &[u8],
+        _value: &[u8],
+        _entry_type: EntryType,
+        _seq: u64,
+        _file_size: u64,
+    ) -> Result<(), CollectorError> {
+        // Mark for compaction if we see a key starting with "compact"
+        if key.starts_with(b"compact") {
+            self.should_compact = true;
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, CollectorError> {
+        Ok(std::iter::empty())
+    }
+
+    fn get_readable_properties(&self) -> impl IntoIterator<Item = &(CString, CString)> {
+        std::iter::empty()
+    }
+
+    fn name(&self) -> &CStr {
+        c"NeedCompactCollector"
+    }
+
+    fn need_compact(&self) -> bool {
+        if self.should_compact {
+            self.returned_need_compact.store(true, Ordering::Relaxed);
+        }
+        self.should_compact
     }
 }

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -1,0 +1,192 @@
+mod util;
+
+use std::ffi::{CStr, CString};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use rust_rocksdb::event_listener::{EventListener, FlushJobInfo};
+use rust_rocksdb::table_properties::{
+    CollectorError, EntryType, TablePropertiesCollector, TablePropertiesCollectorContext,
+    TablePropertiesCollectorFactory, TablePropertiesExt,
+};
+use rust_rocksdb::{Options, DB};
+use util::DBPath;
+
+#[test]
+fn test_table_properties_collector() {
+    let path = DBPath::new("_rust_rocksdb_properties_collector_test");
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+
+    let state = Arc::new(RwLock::new(ObservedProperties::default()));
+    opts.add_event_listener(CustomPropertyListener {
+        state: Arc::clone(&state),
+    });
+
+    let mut cf_opts = Options::default();
+    let match_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    let collector_factory = KeyStartsWithACollectorFactory {
+        name: c"AKeyCounterFactory".to_owned(),
+        match_count: Arc::clone(&match_count),
+        error_count: Arc::clone(&error_count),
+    };
+    cf_opts.add_table_properties_collector_factory(collector_factory);
+
+    let db = DB::open_cf_with_opts(&opts, &path, [("cf", cf_opts)]).unwrap();
+
+    let cf = db.cf_handle("cf").unwrap();
+    db.put_cf(&cf, b"a", b"foo").unwrap();
+    assert_eq!(0, state.read().flush_count);
+    assert_eq!(None, state.read().latest_persisted_key_count);
+    assert_eq!(None, state.read().all_keys);
+
+    db.flush_cf(&cf).unwrap();
+    assert_eq!(1, state.read().flush_count);
+    assert_eq!(
+        Some(c"1".to_owned()),
+        state.read().latest_persisted_key_count
+    );
+    let all_user_keys = state.read().all_keys.clone().unwrap();
+    assert!(all_user_keys.contains(&c"key_count".to_owned()));
+
+    db.put_cf(&cf, b"aaa", b"foo").unwrap();
+    db.put_cf(&cf, b"bbb", b"bar").unwrap();
+    db.put_cf(&cf, b"AAA", b"baz").unwrap();
+
+    assert_eq!(1, state.read().flush_count);
+    assert_eq!(
+        Some(c"1".to_owned()),
+        state.read().latest_persisted_key_count
+    );
+
+    db.flush_cf(&cf).unwrap();
+    assert_eq!(2, state.read().flush_count);
+    assert_eq!(
+        Some(c"3".to_owned()),
+        state.read().latest_persisted_key_count
+    );
+
+    db.put_cf(&cf, b"c", b"").unwrap();
+    db.flush_cf(&cf).unwrap();
+    assert_eq!(3, state.read().flush_count);
+    assert_eq!(
+        Some(c"3".to_owned()),
+        state.read().latest_persisted_key_count
+    );
+
+    // Returning an error from the collector
+    assert_eq!(0, error_count.load(Ordering::Relaxed));
+    db.put_cf(&cf, b"error", b"test").unwrap();
+    db.flush_cf(&cf).unwrap();
+    assert_eq!(4, state.read().flush_count);
+    assert_eq!(None, state.read().latest_persisted_key_count);
+    assert_eq!(1, error_count.load(Ordering::Relaxed));
+}
+
+struct KeyStartsWithACollectorFactory {
+    name: CString,
+    match_count: Arc<AtomicU32>,
+    error_count: Arc<AtomicU32>,
+}
+
+impl TablePropertiesCollectorFactory for KeyStartsWithACollectorFactory {
+    type Collector = KeyStartsWithACollector;
+
+    fn create(&mut self, _context: TablePropertiesCollectorContext) -> Self::Collector {
+        KeyStartsWithACollector {
+            match_count: Arc::clone(&self.match_count),
+            error_count: Arc::clone(&self.error_count),
+            encountered_error: false,
+            props: vec![],
+        }
+    }
+
+    fn name(&self) -> &CStr {
+        &self.name
+    }
+}
+
+#[derive(Debug)]
+struct KeyStartsWithACollector {
+    match_count: Arc<AtomicU32>,
+    error_count: Arc<AtomicU32>,
+    props: Vec<(CString, CString)>,
+    encountered_error: bool,
+}
+
+impl TablePropertiesCollector for KeyStartsWithACollector {
+    fn add_user_key(
+        &mut self,
+        key: &[u8],
+        _value: &[u8],
+        entry_type: EntryType,
+        _seq: u64,
+        _file_size: u64,
+    ) -> Result<(), CollectorError> {
+        if let EntryType::EntryPut = entry_type {
+            if key.starts_with(b"err") {
+                self.error_count.fetch_add(1, Ordering::Relaxed);
+                self.encountered_error = true;
+                return Err(CollectorError::default());
+            }
+
+            if key.starts_with(b"a") || key.starts_with(b"A") {
+                self.match_count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, CollectorError> {
+        if self.encountered_error {
+            return Err(CollectorError::default());
+        }
+
+        self.props.push((
+            c"key_count".to_owned(),
+            CString::new(self.match_count.load(Ordering::Relaxed).to_string()).unwrap(),
+        ));
+
+        Ok(self.props.iter())
+    }
+
+    fn get_readable_properties(&self) -> impl IntoIterator<Item = &(CString, CString)> {
+        self.props.iter()
+    }
+
+    fn name(&self) -> &CStr {
+        c"AKeyCounter"
+    }
+}
+
+struct CustomPropertyListener {
+    state: Arc<RwLock<ObservedProperties>>,
+}
+
+#[derive(Default)]
+struct ObservedProperties {
+    flush_count: u32,
+    latest_persisted_key_count: Option<CString>,
+    all_keys: Option<Vec<CString>>,
+}
+
+impl EventListener for CustomPropertyListener {
+    fn on_flush_completed(&self, info: &FlushJobInfo) {
+        let mut guard = self.state.write();
+        guard.flush_count += 1;
+        guard.latest_persisted_key_count = info
+            .get_user_collected_property("key_count")
+            .map(|cstr| cstr.to_owned());
+        guard.all_keys = Some(
+            info.get_user_collected_property_keys(c"key_")
+                .iter()
+                .map(|&cstr| cstr.to_owned())
+                .collect(),
+        );
+    }
+}

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -1,8 +1,8 @@
 mod util;
 
 use std::ffi::{CStr, CString};
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use parking_lot::RwLock;
 
@@ -11,7 +11,7 @@ use rust_rocksdb::table_properties::{
     CollectorError, EntryType, TablePropertiesCollector, TablePropertiesCollectorContext,
     TablePropertiesCollectorFactory, TablePropertiesExt,
 };
-use rust_rocksdb::{Options, DB};
+use rust_rocksdb::{DB, Options};
 use util::DBPath;
 
 #[test]

--- a/tests/test_write_batch.rs
+++ b/tests/test_write_batch.rs
@@ -324,3 +324,31 @@ fn test_write_batch_merge_vectored_no_cf() {
     let retrieved = db.get(b"merge_key").unwrap();
     assert_eq!(retrieved.unwrap(), b"initialvalue");
 }
+
+#[test]
+fn test_write_batch_with_rollback_to_savepoint() {
+    let path = DBPath::new("writebatch_savepoint");
+    {
+        let db = DB::open_default(&path).expect("DB should open");
+
+        db.put(b"k1", b"v1").unwrap();
+        assert_eq!(db.get(b"k1").unwrap().unwrap(), b"v1");
+
+        let mut batch = WriteBatch::default();
+
+        batch.put(b"k1", b"v2");
+        batch.set_savepoint();
+        batch.put(b"k1", b"v3");
+        batch.set_savepoint();
+        batch.put(b"k1", b"v4");
+        // first rollback
+        batch.rollback_to_savepoint().unwrap();
+        // second rollback
+        batch.rollback_to_savepoint().unwrap();
+        // can't rollback more
+        assert!(batch.rollback_to_savepoint().is_err());
+        db.write(&batch).unwrap();
+
+        assert_eq!(db.get(b"k1").unwrap().unwrap(), b"v2");
+    }
+}

--- a/tests/test_write_batch.rs
+++ b/tests/test_write_batch.rs
@@ -17,7 +17,8 @@ use std::collections::HashMap;
 
 use pretty_assertions::assert_eq;
 
-use rust_rocksdb::{DB, Error, WriteBatch, WriteBatchIterator, WriteBatchIteratorCf};
+use rust_rocksdb::{DB, Error, WriteBatch, WriteBatchIterator, WriteBatchIteratorCf, ColumnFamilyDescriptor, Options, };
+use std::io::IoSlice;
 use util::DBPath;
 
 #[test]
@@ -149,4 +150,177 @@ fn test_write_batch_put_log_data() {
     }
 
     assert!(called);
+}
+
+#[test]
+fn test_write_batch_put_cf_vectored() {
+    let path = DBPath::new("writebatch_put_cf_vectored");
+    let db = DB::open_default(&path).unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"hello";
+    let key_part2 = b"_world";
+    let value_part1 = b"foo";
+    let value_part2 = b"_bar";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put_vectored(&key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get(b"hello_world").unwrap();
+    assert_eq!(retrieved.unwrap(), b"foo_bar");
+}
+
+#[test]
+fn test_write_batch_put_vectored() {
+    let path = DBPath::new("writebatch_put_vectored");
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+
+    let cf_descriptor = ColumnFamilyDescriptor::new("test_cf", Options::default());
+    let db = DB::open_cf_descriptors(&opts, &path, vec![cf_descriptor]).unwrap();
+
+    let cf = db.cf_handle("test_cf").unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"hello";
+    let key_part2 = b"_world";
+    let value_part1 = b"foo";
+    let value_part2 = b"_bar";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put_cf_vectored(&cf, &key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get_cf(&cf, b"hello_world").unwrap();
+    assert_eq!(retrieved.unwrap(), b"foo_bar");
+}
+
+#[test]
+fn test_write_batch_merge_cf_vectored() {
+    fn test_merge_operator(
+        _new_key: &[u8],
+        existing_val: Option<&[u8]>,
+        operands: &rust_rocksdb::MergeOperands,
+    ) -> Option<Vec<u8>> {
+        let mut result: Vec<u8> = Vec::new();
+        if let Some(v) = existing_val {
+            result.extend_from_slice(v);
+        }
+        for op in operands {
+            result.extend_from_slice(op);
+        }
+        Some(result)
+    }
+
+    let path = DBPath::new("writebatch_merge_cf_vectored");
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    opts.set_merge_operator_associative("test_merge", test_merge_operator);
+
+    let mut cf_opts = Options::default();
+    cf_opts.set_merge_operator_associative("test_merge", test_merge_operator);
+    let cf_descriptor = ColumnFamilyDescriptor::new("test_cf", cf_opts);
+    let db = DB::open_cf_descriptors(&opts, &path, vec![cf_descriptor]).unwrap();
+
+    let cf = db.cf_handle("test_cf").unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"merge";
+    let key_part2 = b"_key";
+    let value_part1 = b"val";
+    let value_part2 = b"ue";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put_cf(&cf, b"merge_key", b"initial");
+    batch.merge_cf_vectored(&cf, &key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get_cf(&cf, b"merge_key").unwrap();
+    assert_eq!(retrieved.unwrap(), b"initialvalue");
+}
+
+#[test]
+fn test_write_batch_put_vectored_no_cf() {
+    let path = DBPath::new("writebatch_put_vectored_no_cf");
+    let db = DB::open_default(&path).unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"hello";
+    let key_part2 = b"_world";
+    let value_part1 = b"foo";
+    let value_part2 = b"_bar";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put_vectored(&key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get(b"hello_world").unwrap();
+    assert_eq!(retrieved.unwrap(), b"foo_bar");
+}
+
+#[test]
+fn test_write_batch_merge_vectored_no_cf() {
+    fn test_merge_operator(
+        _new_key: &[u8],
+        existing_val: Option<&[u8]>,
+        operands: &rust_rocksdb::MergeOperands,
+    ) -> Option<Vec<u8>> {
+        let mut result: Vec<u8> = Vec::new();
+        if let Some(v) = existing_val {
+            result.extend_from_slice(v);
+        }
+        for op in operands {
+            result.extend_from_slice(op);
+        }
+        Some(result)
+    }
+
+    let path = DBPath::new("writebatch_merge_vectored_no_cf");
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.set_merge_operator_associative("test_merge", test_merge_operator);
+
+    let db = DB::open(&opts, &path).unwrap();
+
+    let mut batch = WriteBatch::default();
+
+    let key_part1 = b"merge";
+    let key_part2 = b"_key";
+    let value_part1 = b"val";
+    let value_part2 = b"ue";
+
+    let key_slices = [IoSlice::new(key_part1), IoSlice::new(key_part2)];
+    let value_slices = [IoSlice::new(value_part1), IoSlice::new(value_part2)];
+
+    batch.put(b"merge_key", b"initial");
+    batch.merge_vectored(&key_slices, &value_slices);
+
+    let result = db.write(&batch);
+    assert!(result.is_ok());
+
+    let retrieved = db.get(b"merge_key").unwrap();
+    assert_eq!(retrieved.unwrap(), b"initialvalue");
 }

--- a/tests/test_write_batch.rs
+++ b/tests/test_write_batch.rs
@@ -17,7 +17,10 @@ use std::collections::HashMap;
 
 use pretty_assertions::assert_eq;
 
-use rust_rocksdb::{DB, Error, WriteBatch, WriteBatchIterator, WriteBatchIteratorCf, ColumnFamilyDescriptor, Options, };
+use rust_rocksdb::{
+    ColumnFamilyDescriptor, DB, Error, Options, WriteBatch, WriteBatchIterator,
+    WriteBatchIteratorCf,
+};
 use std::io::IoSlice;
 use util::DBPath;
 

--- a/tests/test_write_batch_with_index.rs
+++ b/tests/test_write_batch_with_index.rs
@@ -36,3 +36,69 @@ fn test_write_batch_with_index_with_base_iterator() {
         assert_no_item(&iterator);
     }
 }
+
+#[test]
+fn test_write_batch_with_index_with_rollback_to_savepoint() {
+    let path = DBPath::new("_rust_rocksdb_wbwi_savepoint");
+    {
+        let db = DB::open_default(&path).expect("DB should open");
+
+        db.put(b"k1", b"v1").unwrap();
+        assert_eq!(db.get(b"k1").unwrap().unwrap(), b"v1");
+
+        let mut wbwi = WriteBatchWithIndex::new(0, true);
+
+        let readopts = ReadOptions::default();
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v1"
+        );
+        wbwi.put(b"k1", b"v2");
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v2"
+        );
+        wbwi.set_savepoint();
+        wbwi.put(b"k1", b"v3");
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v3"
+        );
+        wbwi.set_savepoint();
+        wbwi.put(b"k1", b"v4");
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v4"
+        );
+        // first rollback
+        wbwi.rollback_to_savepoint().unwrap();
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v3"
+        );
+        // second rollback
+        wbwi.rollback_to_savepoint().unwrap();
+        assert_eq!(
+            wbwi.get_from_batch_and_db(&db, b"k1", &readopts)
+                .unwrap()
+                .unwrap(),
+            b"v2"
+        );
+
+        // can't rollback more
+        assert!(wbwi.rollback_to_savepoint().is_err());
+        db.write_wbwi(&wbwi).unwrap();
+
+        assert_eq!(db.get(b"k1").unwrap().unwrap(), b"v2");
+    }
+}


### PR DESCRIPTION
## Summary

Rebased onto `restate-0.46.0`. Adds Rust bindings for RocksDB's `table_filter` on `ReadOptions`, allowing iterator scans to skip entire SST files based on their table properties.

### Changes
- **RocksDB submodule**: Updated to include new `rocksdb_readoptions_set_table_filter` C binding in `restate.h`/`restate.cc`
- **`table_properties::TableProperties`**: Borrowed wrapper for use in filter callbacks
- **`ReadOptions::set_table_filter<F>`**: Generic method with `Send + Sync + 'static` bound
- **Integration test**: Verifies SST skipping via user-collected properties

This is useful for speeding up scans when combined with custom `TablePropertiesCollector`s — the filter callback can inspect user-collected properties to decide whether to scan each SST file.