### PR TITLE
Add shareable RateLimiter wrapper for cross-DB rate limiting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.46.0"
+version = "0.46.1"
 edition = "2024"
 rust-version = "1.89.0"
 authors = [

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -24,6 +24,7 @@ use crate::cache::Cache;
 use crate::column_family::ColumnFamilyTtl;
 use crate::event_listener::{EventListener, new_event_listener};
 use crate::ffi_util::from_cstr_and_free;
+use crate::rate_limiter::RateLimiter;
 use crate::sst_file_manager::SstFileManager;
 use crate::statistics::{Histogram, HistogramData, StatsLevel};
 use crate::write_buffer_manager::WriteBufferManager;
@@ -63,6 +64,7 @@ pub(crate) struct OptionsMustOutliveDB {
     block_based: Option<BlockBasedOptionsMustOutliveDB>,
     write_buffer_manager: Option<WriteBufferManager>,
     sst_file_manager: Option<SstFileManager>,
+    rate_limiter: Option<RateLimiter>,
     log_callback: Option<Arc<LogCallback>>,
     comparator: Option<Arc<OwnedComparator>>,
     compaction_filter: Option<Arc<OwnedCompactionFilter>>,
@@ -79,6 +81,7 @@ impl OptionsMustOutliveDB {
                 .as_ref()
                 .map(BlockBasedOptionsMustOutliveDB::clone),
             write_buffer_manager: self.write_buffer_manager.clone(),
+            rate_limiter: self.rate_limiter.clone(),
             sst_file_manager: self.sst_file_manager.clone(),
             log_callback: self.log_callback.clone(),
             comparator: self.comparator.clone(),
@@ -3417,6 +3420,33 @@ impl Options {
             ffi::rocksdb_options_set_ratelimiter(self.inner, ratelimiter);
             ffi::rocksdb_ratelimiter_destroy(ratelimiter);
         }
+    }
+
+    /// Sets a shared rate limiter that can be used across multiple DB instances.
+    ///
+    /// Unlike [`set_ratelimiter`](Options::set_ratelimiter) and similar methods
+    /// that create and immediately consume a rate limiter, this method accepts a
+    /// pre-created [`RateLimiter`] that can be cloned and shared across multiple
+    /// `Options` / DB instances to enforce a single global rate limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_rocksdb::{Options, RateLimiter, RateLimiterMode};
+    ///
+    /// let limiter = RateLimiter::new(10 * 1024 * 1024, 100_000, 10, RateLimiterMode::KAllIo, false);
+    ///
+    /// let mut opts1 = Options::default();
+    /// opts1.set_shared_ratelimiter(&limiter);
+    ///
+    /// let mut opts2 = Options::default();
+    /// opts2.set_shared_ratelimiter(&limiter);
+    /// ```
+    pub fn set_shared_ratelimiter(&mut self, limiter: &RateLimiter) {
+        unsafe {
+            ffi::rocksdb_options_set_ratelimiter(self.inner, limiter.0.inner.as_ptr());
+        }
+        self.outlive.rate_limiter = Some(limiter.clone());
     }
 
     /// Sets the maximal size of the info log file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ pub mod merge_operator;
 pub mod perf;
 mod prop_name;
 pub mod properties;
+mod rate_limiter;
 mod slice_transform;
 mod snapshot;
 pub mod sst_file_manager;
@@ -144,6 +145,7 @@ pub use crate::{
     iter_range::{IterateBounds, PrefixRange},
     merge_operator::MergeOperands,
     perf::{PerfContext, PerfMetric, PerfStatsLevel},
+    rate_limiter::RateLimiter,
     slice_transform::SliceTransform,
     snapshot::{Snapshot, SnapshotWithThreadMode},
     sst_file_manager::SstFileManager,
@@ -260,6 +262,7 @@ mod test {
         OptimisticTransactionDB, OptimisticTransactionOptions, Transaction, TransactionDB,
         TransactionDBOptions, TransactionOptions,
         cache::{Cache, CacheWrapper},
+        rate_limiter::{RateLimiter, RateLimiterWrapper},
         write_buffer_manager::{WriteBufferManager, WriteBufferManagerWrapper},
     };
 
@@ -306,6 +309,8 @@ mod test {
         is_send::<TransactionDBOptions>();
         is_send::<OptimisticTransactionOptions>();
         is_send::<TransactionOptions>();
+        is_send::<RateLimiter>();
+        is_send::<RateLimiterWrapper>();
         is_send::<WriteBufferManager>();
         is_send::<WriteBufferManagerWrapper>();
     }
@@ -339,6 +344,8 @@ mod test {
         is_sync::<TransactionDBOptions>();
         is_sync::<OptimisticTransactionOptions>();
         is_sync::<TransactionOptions>();
+        is_sync::<RateLimiter>();
+        is_sync::<RateLimiterWrapper>();
         is_sync::<WriteBufferManager>();
         is_sync::<WriteBufferManagerWrapper>();
     }

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,0 +1,87 @@
+use crate::db_options::RateLimiterMode;
+use crate::ffi;
+use libc::c_int;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+pub(crate) struct RateLimiterWrapper {
+    pub(crate) inner: NonNull<ffi::rocksdb_ratelimiter_t>,
+}
+
+unsafe impl Send for RateLimiterWrapper {}
+unsafe impl Sync for RateLimiterWrapper {}
+
+impl Drop for RateLimiterWrapper {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_ratelimiter_destroy(self.inner.as_ptr());
+        }
+    }
+}
+
+/// A `RateLimiter` can be shared across multiple DB instances to control the
+/// total write rate of flush and compaction.
+///
+/// Use [`Options::set_shared_ratelimiter`](crate::Options::set_shared_ratelimiter) to
+/// assign a rate limiter to a DB.
+///
+/// # Examples
+///
+/// ```
+/// use rust_rocksdb::{Options, RateLimiter, RateLimiterMode};
+///
+/// let limiter = RateLimiter::new(10 * 1024 * 1024, 100_000, 10, RateLimiterMode::KAllIo, false);
+///
+/// let mut opts1 = Options::default();
+/// opts1.create_if_missing(true);
+/// opts1.set_shared_ratelimiter(&limiter);
+///
+/// let mut opts2 = Options::default();
+/// opts2.create_if_missing(true);
+/// opts2.set_shared_ratelimiter(&limiter);
+/// ```
+#[derive(Clone)]
+pub struct RateLimiter(pub(crate) Arc<RateLimiterWrapper>);
+
+impl RateLimiter {
+    /// Creates a new rate limiter.
+    ///
+    /// `rate_bytes_per_sec`: controls the total write rate of compaction and
+    /// flush in bytes per second. Currently, RocksDB does not enforce rate
+    /// limit for anything other than flush and compaction, e.g. write to WAL.
+    ///
+    /// `refill_period_us`: controls how often tokens are refilled. For example,
+    /// when `rate_bytes_per_sec` is set to 10MB/s and `refill_period_us` is set
+    /// to 100ms, then 1MB is refilled every 100ms internally. Larger values can
+    /// lead to burstier writes while smaller values introduce more CPU overhead.
+    ///
+    /// `fairness`: RateLimiter accepts high-pri and low-pri requests. A low-pri
+    /// request is usually blocked in favor of hi-pri request. This fairness
+    /// parameter grants low-pri requests permission by `1/fairness` chance even
+    /// when high-pri requests exist to avoid starvation. Default: 10.
+    ///
+    /// `mode`: indicates which types of operations count against the limit.
+    ///
+    /// `auto_tuned`: enables dynamic adjustment of rate limit within the range
+    /// `[rate_bytes_per_sec / 20, rate_bytes_per_sec]`, according to the recent
+    /// demand for background I/O.
+    pub fn new(
+        rate_bytes_per_sec: i64,
+        refill_period_us: i64,
+        fairness: i32,
+        mode: RateLimiterMode,
+        auto_tuned: bool,
+    ) -> Self {
+        let inner = NonNull::new(unsafe {
+            ffi::rocksdb_ratelimiter_create_with_mode(
+                rate_bytes_per_sec,
+                refill_period_us,
+                fairness,
+                mode as c_int,
+                auto_tuned,
+            )
+        })
+        .unwrap();
+        RateLimiter(Arc::new(RateLimiterWrapper { inner }))
+    }
+}

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -25,9 +25,9 @@ use rust_rocksdb::{
     BlockBasedOptions, BottommostLevelCompaction, Cache, ColumnFamilyDescriptor, ColumnFamilyTtl,
     CompactOptions, CuckooTableOptions, DB, DBAccess, DBCompactionStyle, DBWithThreadMode,
     DEFAULT_COLUMN_FAMILY_NAME, Env, Error, ErrorKind, FifoCompactOptions, IteratorMode,
-    MultiThreaded, Options, PerfContext, PerfMetric, RateLimiterMode, ReadOptions, SingleThreaded,
-    SliceTransform, Snapshot, UniversalCompactOptions, UniversalCompactionStopStyle,
-    WaitForCompactOptions, WriteBatch, perf::get_memory_usage_stats,
+    MultiThreaded, Options, PerfContext, PerfMetric, RateLimiter, RateLimiterMode, ReadOptions,
+    SingleThreaded, SliceTransform, Snapshot, UniversalCompactOptions,
+    UniversalCompactionStopStyle, WaitForCompactOptions, WriteBatch, perf::get_memory_usage_stats,
 };
 use util::{DBPath, U64Comparator, U64Timestamp, assert_iter, pair};
 
@@ -1927,4 +1927,41 @@ fn test_enable_and_disable_file_deletions() {
 
         let _ = DB::destroy(&Options::default(), &path);
     }
+}
+
+#[test]
+fn shared_ratelimiter_test() {
+    let path1 = DBPath::new("_rust_rocksdb_shared_ratelimiter_1");
+    let path2 = DBPath::new("_rust_rocksdb_shared_ratelimiter_2");
+
+    // Create a single shared rate limiter.
+    let limiter = RateLimiter::new(10_000_000, 100_000, 10, RateLimiterMode::KAllIo, false);
+
+    // Open two DBs sharing the same rate limiter.
+    let mut opts1 = Options::default();
+    opts1.create_if_missing(true);
+    opts1.set_shared_ratelimiter(&limiter);
+
+    let mut opts2 = Options::default();
+    opts2.create_if_missing(true);
+    opts2.set_shared_ratelimiter(&limiter);
+
+    let db1 = DB::open(&opts1, &path1).unwrap();
+    let db2 = DB::open(&opts2, &path2).unwrap();
+
+    // Write to both DBs.
+    for i in 0..100 {
+        let key = format!("key{i}");
+        let val = format!("val{i}");
+        db1.put(key.as_bytes(), val.as_bytes()).unwrap();
+        db2.put(key.as_bytes(), val.as_bytes()).unwrap();
+    }
+
+    // Verify reads work.
+    assert_eq!(db1.get(b"key0").unwrap().unwrap(), b"val0");
+    assert_eq!(db2.get(b"key99").unwrap().unwrap(), b"val99");
+
+    // Drop DBs before Options (Options outlive DB is enforced by the wrapper).
+    drop(db1);
+    drop(db2);
 }


### PR DESCRIPTION
## Summary

- Adds a `RateLimiter` type (`Arc`-wrapped, `Clone`, `Send + Sync`) that can be shared across multiple DB instances via `Options::set_shared_ratelimiter()`
- Follows the same pattern used by `Cache`, `Env`, and `WriteBufferManager` for shareable objects
- Bumps crate version to 0.46.1

## Motivation

The existing `set_ratelimiter` / `set_auto_tuned_ratelimiter` / `set_ratelimiter_with_mode` methods create a rate limiter inline and immediately destroy the handle after passing it to the C++ options (which copies the internal `shared_ptr`). This means each DB gets an independent rate limiter instance, making it impossible to enforce a single global write rate across multiple DBs.

The new `RateLimiter` type holds the C handle behind `Arc` so it can be cloned and passed to multiple `Options`, ensuring all DBs share the same underlying C++ `GenericRateLimiter`.