### PR TITLE
Add Iterator::Refresh() bindings

### DIFF
--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -150,6 +150,21 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
         Ok(())
     }
 
+    /// Refreshes the iterator to represent the latest state of the DB.
+    /// The iterator is invalidated after this call and must be re-sought
+    /// before use.
+    ///
+    /// If the iterator was created with a snapshot, the refreshed iterator
+    /// will no longer use that snapshot and will instead read the latest
+    /// DB state. The snapshot itself is not released; it remains valid and
+    /// will be released when the owning [`crate::SnapshotWithThreadMode`] is dropped.
+    pub fn refresh(&mut self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_iter_refresh(self.inner.as_ptr()));
+        }
+        Ok(())
+    }
+
     /// Seeks to the first key in the database.
     ///
     /// # Examples
@@ -523,6 +538,16 @@ impl<'a, D: DBAccess> DBIteratorWithThreadMode<'a, D> {
                 Direction::Reverse
             }
         };
+    }
+
+    /// Refreshes the iterator, then re-seeks using the given mode.
+    ///
+    /// After a refresh the underlying iterator is invalidated, so a mode
+    /// must be provided to reposition it.
+    pub fn refresh(&mut self, mode: IteratorMode) -> Result<(), Error> {
+        self.raw.refresh()?;
+        self.set_mode(mode);
+        Ok(())
     }
 }
 

--- a/tests/test_raw_iterator.rs
+++ b/tests/test_raw_iterator.rs
@@ -15,7 +15,7 @@
 mod util;
 
 use crate::util::{assert_item, assert_no_item};
-use rust_rocksdb::DB;
+use rust_rocksdb::{DB, ReadOptions};
 use util::DBPath;
 
 #[test]
@@ -133,5 +133,59 @@ pub fn test_next_without_seek() {
 
         let mut iter = db.raw_iterator();
         iter.next();
+    }
+}
+
+#[test]
+pub fn test_refresh() {
+    let n = DBPath::new("test_refresh");
+    {
+        let db = DB::open_default(&n).unwrap();
+        db.put(b"k1", b"v1").unwrap();
+
+        let mut iter = db.raw_iterator();
+        iter.seek_to_first();
+        assert_item(&iter, b"k1", b"v1");
+
+        // Write new data after iterator was created
+        db.put(b"k2", b"v2").unwrap();
+
+        // Iterator doesn't see k2 yet
+        iter.seek(b"k2");
+        assert_no_item(&iter);
+
+        // After refresh, the iterator sees k2
+        iter.refresh().unwrap();
+        iter.seek(b"k2");
+        assert_item(&iter, b"k2", b"v2");
+    }
+}
+
+#[test]
+pub fn test_refresh_with_snapshot() {
+    let n = DBPath::new("test_refresh_snapshot");
+    {
+        let db = DB::open_default(&n).unwrap();
+        db.put(b"k1", b"v1").unwrap();
+
+        let snapshot = db.snapshot();
+        let mut readopts = ReadOptions::default();
+        readopts.set_snapshot(&snapshot);
+        let mut iter = db.raw_iterator_opt(readopts);
+        iter.seek_to_first();
+        assert_item(&iter, b"k1", b"v1");
+
+        // Write new data after snapshot was taken
+        db.put(b"k2", b"v2").unwrap();
+
+        // Snapshot iterator doesn't see k2 yet
+        iter.seek(b"k2");
+        assert_no_item(&iter);
+
+        // After refresh, the iterator no longer honors the snapshot and
+        // instead reads the latest DB state, so k2 is now visible
+        iter.refresh().unwrap();
+        iter.seek(b"k2");
+        assert_item(&iter, b"k2", b"v2");
     }
 }


### PR DESCRIPTION
## Summary

- Cherry-pick of rust-rocksdb/rust-rocksdb@a4f178d
- Exposes `rocksdb_iter_refresh` (available since RocksDB 10.7.5 C API) through safe Rust wrappers on both `DBRawIteratorWithThreadMode` and `DBIteratorWithThreadMode`
- After refresh, the iterator sees the latest DB state without needing to destroy and recreate it

## Changes

- `DBRawIteratorWithThreadMode::refresh()` — refreshes the underlying iterator; must be re-sought before use
- `DBIteratorWithThreadMode::refresh(mode)` — refreshes and re-seeks with the given `IteratorMode`
- Tests for both raw and high-level iterator refresh, including snapshot behavior