### PR TITLE
Cherry-pick upstream rust-rocksdb fixes: build defines + aarch64 CRC32

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -67,4 +67,3 @@ cc = { version = "1.2", features = ["parallel"] }
 bindgen = { version = "0.72", default-features = false }
 glob = "0.3"
 pkg-config = { version = "0.3", optional = true }
-libc = "0.2"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1,9 +1,6 @@
 use std::path::Path;
 use std::{env, fs, path::PathBuf, process::Command};
 
-#[cfg(target_os = "linux")]
-use libc::{AT_HWCAP, getauxval};
-
 // On these platforms jemalloc-sys will use a prefixed jemalloc which cannot be linked together
 // with RocksDB.
 // See https://github.com/tikv/jemallocator/blob/f7adfca5aff272b43fd3ad896252b57fbbd9c72a/jemalloc-sys/src/env.rs#L24
@@ -53,18 +50,6 @@ fn bindgen_rocksdb() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("unable to write rocksdb bindings");
-}
-
-#[cfg(target_os = "linux")]
-fn check_getauxval_supported() -> bool {
-    unsafe {
-        let aux_value = getauxval(AT_HWCAP);
-        if aux_value == 0 {
-            return false;
-        }
-
-        true
-    }
 }
 
 fn build_rocksdb() {
@@ -134,6 +119,15 @@ fn build_rocksdb() {
 
     config.include(".");
     config.define("NDEBUG", Some("1"));
+
+    // true for C++ >= 17; we set -std=c++20 below
+    config.define("HAVE_ALIGNED_NEW", None);
+
+    // __uint128_t is supported by GCC and Clang; Don't use it for MSVC
+    // TODO: implement a detection script?
+    if !target.contains("msvc") {
+        config.define("HAVE_UINT128_EXTENSION", None);
+    }
 
     let mut lib_sources = include_str!("rocksdb_lib_sources.txt")
         .trim()
@@ -211,11 +205,9 @@ fn build_rocksdb() {
         config.define("ROCKSDB_PLATFORM_POSIX", None);
         config.define("ROCKSDB_LIB_IO_POSIX", None);
         config.define("ROCKSDB_SCHED_GETCPU_PRESENT", None);
-
-        #[cfg(target_os = "linux")]
-        if check_getauxval_supported() {
-            config.define("ROCKSDB_AUXV_GETAUXVAL_PRESENT", None);
-        }
+        config.define("ROCKSDB_AUXV_GETAUXVAL_PRESENT", None);
+        config.define("ROCKSDB_FALLOCATE_PRESENT", None);
+        config.define("ROCKSDB_RANGESYNC_PRESENT", None);
     } else if target.contains("dragonfly") {
         config.define("OS_DRAGONFLYBSD", None);
         config.define("ROCKSDB_PLATFORM_POSIX", None);
@@ -281,8 +273,6 @@ fn build_rocksdb() {
         }
     }
 
-    config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", None);
-
     if cfg!(feature = "jemalloc") && NO_JEMALLOC_TARGETS.iter().all(|i| !target.contains(i)) {
         config.define("ROCKSDB_JEMALLOC", Some("1"));
         config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
@@ -310,6 +300,7 @@ fn build_rocksdb() {
             config.static_crt(true);
         }
         config.flag("-EHsc");
+        // Don't use cxx_standard: Uses : instead of =
         config.flag("-std:c++20");
     } else {
         config.flag(cxx_standard());
@@ -335,7 +326,6 @@ fn build_rocksdb() {
     config.file("build_version.cc");
 
     config.cpp(true);
-    config.flag_if_supported("-std=c++20");
 
     if !target.contains("windows") {
         config.flag("-include").flag("cstdint");
@@ -402,6 +392,8 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
     false
 }
 
+/// Returns the value of the `ROCKSDB_CXX_STD` env var, or the default `-std=c++{version}` flag for
+/// building RocksDB.
 fn cxx_standard() -> String {
     env::var("ROCKSDB_CXX_STD").map_or("-std=c++20".to_owned(), |cxx_std| {
         if !cxx_std.starts_with("-std=") {

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -52,8 +52,55 @@ fn bindgen_rocksdb() {
         .expect("unable to write rocksdb bindings");
 }
 
+/// Splits `CARGO_ENCODED_RUSTFLAGS` into a Vec.
+fn split_encoded_rustflags() -> Vec<String> {
+    let flags = std::env::var("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default();
+
+    // extra flags that Cargo invokes rustc with, separated by a 0x1f character
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+    flags.split("\x1f").map(|flag| flag.to_string()).collect()
+}
+
+/// Returns the argument to `-Ctarget-cpu=` if it exists.
+fn get_target_cpu_flag() -> Option<String> {
+    const TARGET_CPU_FLAG: &str = "-Ctarget-cpu=";
+    let flags = split_encoded_rustflags();
+    let complete_flag = flags.iter().find(|flag| flag.starts_with(TARGET_CPU_FLAG));
+    complete_flag.map(|flag| flag[TARGET_CPU_FLAG.len()..].to_string())
+}
+
+/// If the Rust `-Ctarget-cpu=` option is set, this attempts to pass it through to the C/C++
+/// compiler. It should print a Cargo build warning if the compiler does not support the flag,
+/// or if the architecture is not supported.
+fn pass_through_target_cpu(cfg: &mut cc::Build) {
+    let Some(target_cpu_flag) = get_target_cpu_flag() else {
+        return;
+    };
+
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    match arch.as_str() {
+        "x86_64" => {
+            cfg.flag_if_supported(format!("-march={target_cpu_flag}"));
+        }
+        "aarch64" => {
+            cfg.flag_if_supported(format!("-mcpu={target_cpu_flag}"));
+        }
+        // TODO: add more architectures/compilers
+        _ => {
+            println!(
+                "cargo::warning=unknown target architecture: {arch}; C/C++ target flags not passed through"
+            );
+        }
+    }
+}
+
 fn build_rocksdb() {
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html
     let target = env::var("TARGET").unwrap();
+    // https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_features_env = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+    let target_features: Vec<_> = target_features_env.split(',').collect();
 
     let mut config = cc::Build::new();
     config.include("rocksdb/include/");
@@ -137,15 +184,14 @@ fn build_rocksdb() {
         .filter(|file| !matches!(*file, "util/build_version.cc"))
         .collect::<Vec<&'static str>>();
 
-    if let (true, Ok(target_feature_value)) = (
-        target.contains("x86_64"),
-        env::var("CARGO_CFG_TARGET_FEATURE"),
-    ) {
+    // attempt to pass through the RUSTFLAGS -Ctarget-cpu to allow the same optimizations for C/C++
+    pass_through_target_cpu(&mut config);
+
+    // CPU-specific build configuration
+    if target_arch == "x86_64" {
         // This is needed to enable hardware CRC32C. Technically, SSE 4.2 is
         // only available since Intel Nehalem (about 2010) and AMD Bulldozer
         // (about 2011).
-        let target_features: Vec<_> = target_feature_value.split(',').collect();
-
         if target_features.contains(&"sse2") {
             config.flag_if_supported("-msse2");
         }
@@ -154,6 +200,10 @@ fn build_rocksdb() {
         }
         if target_features.contains(&"sse4.2") {
             config.flag_if_supported("-msse4.2");
+        } else {
+            println!(
+                r#"cargo::warning=compiling without SSE4.2: CRC will be slow (set RUSTFLAGS="-Ctarget-cpu=..." to optimize RocksDB e.g. -Ctarget-cpu=broadwell)"#
+            );
         }
         // Pass along additional target features as defined in
         // build_tools/build_detect_platform.
@@ -166,8 +216,32 @@ fn build_rocksdb() {
         if target_features.contains(&"lzcnt") {
             config.flag_if_supported("-mlzcnt");
         }
+
         if !target.contains("android") && target_features.contains(&"pclmulqdq") {
             config.flag_if_supported("-mpclmul");
+        }
+
+        if target_features.contains(&"avx") && !target_features.contains(&"pclmulqdq") {
+            // RocksDB BUG (<= 10.11.0/2026-01-23): assumes AVX implies -mpclmul
+            // x86-64-v3/-v4 does not include PCLMUL
+            println!(
+                r#"cargo:warning=RocksDB BUG: target arch missing -mpclmul; compile may fail: pass named architecture e.g. -Ctarget-cpu=broadwell"#
+            );
+        }
+    } else if target_arch == "aarch64" {
+        if target_features.contains(&"crc") && target_features.contains(&"aes") {
+            // the target supports the instructions RocksDB needs: if we don't have a target-cpu,
+            // use -march=armv8-a+crc+aes+crypto, like the RocksDB Makefile.
+            // If we DO have a target-cpu, assume pass_through_target_cpu() has set it above
+            if get_target_cpu_flag().is_none() {
+                // TODO: Should just be +crc+aes but RocksDB checks for __ARM_FEATURE_CRYPTO
+                // https://github.com/facebook/rocksdb/pull/14217
+                config.flag_if_supported("-march=armv8-a+crc+aes+crypto");
+            }
+        } else {
+            println!(
+                r#"cargo:warning=building for aarch64 WITHOUT CRC instruction: build with RUSTFLAGS="-Ctarget-cpu=..." to optimize RocksDB e.g. -Ctarget-cpu=neoverse-n1"#
+            );
         }
     }
 

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -691,3 +691,94 @@ fn jemalloc_init() {
         assert!(log_content.contains("Jemalloc supported: 0"));
     }
 }
+
+// Verify we passed through the compiler flags to enable hardware CRC32 (if supported).
+#[test]
+fn test_crc32_build() {
+    let path = DBPath::new("_crc32");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        let _db = DB::open(&opts, &path).unwrap();
+    }
+
+    let mut rocksdb_log =
+        fs::File::open((&path).as_ref().join("LOG")).expect("rocksdb creates a LOG file");
+    let mut log_content = String::new();
+    rocksdb_log
+        .read_to_string(&mut log_content)
+        .expect("can read the LOG file");
+
+    // look for the log line with prefix "Fast CRC32 supported:"
+    let log_line = log_content
+        .lines()
+        .find(|line| line.contains("Fast CRC32 supported:"));
+    assert!(log_line.is_some(), "{log_content}");
+    let log_line = log_line.unwrap();
+
+    let expected_supported = if cfg!(target_arch = "x86_64") {
+        // Default Linux x86-64 (x86-64-v1) does not support CRC32. Nearly all CPUs since ~2014
+        // should support it (>= x86-64-v2), but RocksDB only does compile-time detection.
+        // Our build.rs should match the Rust target settings
+        if cfg!(target_feature = "crc") {
+            Some(true)
+        } else {
+            Some(false)
+        }
+    } else if cfg!(target_arch = "aarch64") {
+        // Default Linux aarch64 does not support CRC32. RocksDB's runtime feature detection is
+        // also buggy as of 10.110 (2026-01-23), but it should report "Supported" if the feature is
+        // enabled at compile time.
+        if cfg!(target_feature = "crc") {
+            Some(true)
+        } else {
+            // TODO: Fix when upstream RocksDB fixes the runtime feature detection
+            Some(false)
+        }
+    } else {
+        println!(
+            "TODO: test_crc32_build needs to be extended to support ARCH={}",
+            std::env::consts::ARCH
+        );
+        None
+    };
+    if let Some(expected_supported) = expected_supported {
+        if expected_supported {
+            assert!(
+                log_line.contains("Supported on "),
+                "expected 'Supported on ' log_line={log_line}"
+            );
+        } else {
+            assert!(
+                log_line.contains("Not supported on "),
+                "expected 'Not supported on ' log_line={log_line}"
+            );
+        }
+    }
+
+    // split the last word as the supported arch
+    let crc32_supported_arch = log_line.split_whitespace().last().unwrap();
+
+    // Verify that the RocksDB reported architecture matches this test
+    // this may fail if RocksDB changes its string formatting
+    let expected_arch = if cfg!(target_arch = "x86_64") {
+        "x86".to_string()
+    } else if cfg!(target_arch = "aarch64") {
+        // TODO: RocksDB has a bug: it can report x86 when the CRC feature is not enabled
+        // This should just be "Arm64" when the RocksDB bug is fixed
+        if cfg!(target_feature = "crc") {
+            "Arm64".to_string()
+        } else {
+            "x86".to_string()
+        }
+    } else if cfg!(target_arch = "powerpc64") {
+        "PPC".to_string()
+    } else {
+        format!("unknown Rust ARCH={} (fix test)", std::env::consts::ARCH)
+    };
+
+    assert_eq!(
+        crc32_supported_arch, expected_arch,
+        "Expected CRC32 support for architecture '{expected_arch}', but RocksDB reported support for '{crc32_supported_arch}'"
+    );
+}


### PR DESCRIPTION
## Summary

Cherry-picks two commits from `rust-rocksdb/rust-rocksdb` that are missing from the `zaidoon1` fork:

- **`fc78567`** — Sync build.rs defines with upstream RocksDB: adds `HAVE_ALIGNED_NEW`, `HAVE_UINT128_EXTENSION`, `ROCKSDB_FALLOCATE_PRESENT`, `ROCKSDB_RANGESYNC_PRESENT`; removes stale `ROCKSDB_SUPPORT_THREAD_LOCAL` and duplicate `-std=c++20` flag
- **`22513cd`** — Pass through `-Ctarget-cpu` to C/C++ compiler and add aarch64 CRC32/AES hardware instruction support, which is a substantial performance improvement for RocksDB WAL on ARM (e.g. AWS Graviton)

Both had minor conflicts in `build.rs` around the Linux `ROCKSDB_AUXV_GETAUXVAL_PRESENT` define. Our fork previously gated this behind a runtime `getauxval` check — resolved by switching to an unconditional define matching upstream, and removing the now-dead `check_getauxval_supported()` function and `libc` build-dependency.