### PR TITLE
Add ReadOptions::set_table_filter for skipping SSTs during iteration

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -44,6 +44,7 @@ use crate::{
     },
     slice_transform::SliceTransform,
     statistics::Ticker,
+    table_properties::TableProperties,
 };
 
 // must be Send and Sync because it will be called by RocksDB from different threads
@@ -4430,6 +4431,38 @@ impl ReadOptions {
         self.iter_start_ts = ts;
         unsafe {
             ffi::rocksdb_readoptions_set_iter_start_ts(self.inner, ptr, len);
+        }
+    }
+
+    /// Sets a table filter callback that is invoked for each SST file during
+    /// iteration. Return `false` to skip scanning a table entirely. This only
+    /// affects iterators, not point lookups.
+    pub fn set_table_filter<F>(&mut self, filter: F)
+    where
+        F: Fn(&TableProperties) -> bool + Send + Sync + 'static,
+    {
+        type FilterFn = Box<dyn Fn(&TableProperties) -> bool + Send + Sync>;
+
+        unsafe extern "C" fn call(
+            state: *mut c_void,
+            props: *const ffi::rocksdb_table_properties_t,
+        ) -> c_uchar {
+            let filter = unsafe { &**(state as *const FilterFn) };
+            let props = unsafe { TableProperties::from_raw(props) };
+            c_uchar::from(filter(&props))
+        }
+
+        unsafe extern "C" fn destroy(state: *mut c_void) {
+            drop(unsafe { Box::from_raw(state as *mut FilterFn) });
+        }
+
+        // Double-box: the outer Box<FilterFn> gives us a thin pointer we
+        // can round-trip through *mut c_void in the C callbacks.
+        let boxed: Box<FilterFn> = Box::new(Box::new(filter));
+        let state = Box::into_raw(boxed) as *mut c_void;
+
+        unsafe {
+            ffi::rocksdb_readoptions_set_table_filter(self.inner, state, Some(call), Some(destroy));
         }
     }
 }

--- a/src/table_properties.rs
+++ b/src/table_properties.rs
@@ -297,3 +297,31 @@ where
         collector.need_compact()
     }
 }
+
+/// Borrowed reference to a table's properties, valid for the duration of a filter callback.
+///
+/// Provides access to user-collected properties set by a [`TablePropertiesCollector`].
+pub struct TableProperties {
+    raw: *const ffi::rocksdb_table_properties_t,
+}
+
+impl TableProperties {
+    /// Wraps a raw pointer for the duration of a callback. The caller must ensure
+    /// the pointer remains valid for the lifetime of the returned value.
+    pub(crate) unsafe fn from_raw(raw: *const ffi::rocksdb_table_properties_t) -> Self {
+        Self { raw }
+    }
+
+    /// Returns the value of a user-collected property by key, or `None` if it doesn't exist.
+    pub fn get_user_collected_property(&self, key: &CStr) -> Option<&CStr> {
+        unsafe {
+            let val =
+                ffi::rocksdb_table_properties_get_user_collected_property(self.raw, key.as_ptr());
+            if val.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(val))
+            }
+        }
+    }
+}

--- a/tests/test_table_filter.rs
+++ b/tests/test_table_filter.rs
@@ -1,0 +1,137 @@
+mod util;
+
+use std::ffi::{CStr, CString};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use rust_rocksdb::table_properties::{
+    CollectorError, EntryType, TableProperties, TablePropertiesCollector,
+    TablePropertiesCollectorContext, TablePropertiesCollectorFactory, TablePropertiesExt,
+};
+use rust_rocksdb::{DB, IteratorMode, Options, ReadOptions};
+use util::DBPath;
+
+/// Counts Put entries and stores the count as a user-collected property "entry_count".
+struct EntryCountCollectorFactory;
+
+impl TablePropertiesCollectorFactory for EntryCountCollectorFactory {
+    type Collector = EntryCountCollector;
+
+    fn create(&mut self, _context: TablePropertiesCollectorContext) -> Self::Collector {
+        EntryCountCollector {
+            count: 0,
+            props: vec![],
+        }
+    }
+
+    fn name(&self) -> &CStr {
+        c"EntryCountCollectorFactory"
+    }
+}
+
+struct EntryCountCollector {
+    count: u32,
+    props: Vec<(CString, CString)>,
+}
+
+impl TablePropertiesCollector for EntryCountCollector {
+    fn add_user_key(
+        &mut self,
+        _key: &[u8],
+        _value: &[u8],
+        entry_type: EntryType,
+        _seq: u64,
+        _file_size: u64,
+    ) -> Result<(), CollectorError> {
+        if let EntryType::EntryPut = entry_type {
+            self.count += 1;
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<impl IntoIterator<Item = &(CString, CString)>, CollectorError> {
+        self.props.push((
+            c"entry_count".to_owned(),
+            CString::new(self.count.to_string()).unwrap(),
+        ));
+        Ok(self.props.iter())
+    }
+
+    fn get_readable_properties(&self) -> impl IntoIterator<Item = &(CString, CString)> {
+        self.props.iter()
+    }
+
+    fn name(&self) -> &CStr {
+        c"EntryCountCollector"
+    }
+}
+
+#[test]
+fn test_table_filter_skips_sst() {
+    let path = DBPath::new("_rust_rocksdb_table_filter_test");
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.add_table_properties_collector_factory(EntryCountCollectorFactory);
+    // Disable auto-compaction so our 3 SSTs stay separate
+    opts.set_disable_auto_compactions(true);
+
+    let db = DB::open(&opts, &path).unwrap();
+
+    // SST 1: 1 entry (key "a")
+    db.put(b"a", b"val_a").unwrap();
+    db.flush().unwrap();
+
+    // SST 2: 2 entries (keys "b", "c")
+    db.put(b"b", b"val_b").unwrap();
+    db.put(b"c", b"val_c").unwrap();
+    db.flush().unwrap();
+
+    // SST 3: 3 entries (keys "d", "e", "f")
+    db.put(b"d", b"val_d").unwrap();
+    db.put(b"e", b"val_e").unwrap();
+    db.put(b"f", b"val_f").unwrap();
+    db.flush().unwrap();
+
+    // Without filter: all 6 keys
+    let all_keys: Vec<_> = db
+        .iterator(IteratorMode::Start)
+        .map(|r| r.unwrap().0.to_vec())
+        .collect();
+    assert_eq!(
+        all_keys,
+        vec![
+            b"a".to_vec(),
+            b"b".to_vec(),
+            b"c".to_vec(),
+            b"d".to_vec(),
+            b"e".to_vec(),
+            b"f".to_vec()
+        ]
+    );
+
+    // With filter: skip SSTs that have entry_count == "2"
+    let mut read_opts = ReadOptions::default();
+    let filter_call_count = Arc::new(AtomicU32::new(0));
+    let counter = Arc::clone(&filter_call_count);
+    read_opts.set_table_filter(move |props: &TableProperties| {
+        counter.fetch_add(1, Ordering::Relaxed);
+        let count = props.get_user_collected_property(c"entry_count");
+        // Keep tables where entry_count != "2"
+        count != Some(c"2")
+    });
+
+    let filtered_keys: Vec<_> = db
+        .iterator_opt(IteratorMode::Start, read_opts)
+        .map(|r| r.unwrap().0.to_vec())
+        .collect();
+
+    // SST 2 (keys b, c) should be skipped
+    assert_eq!(
+        filtered_keys,
+        vec![b"a".to_vec(), b"d".to_vec(), b"e".to_vec(), b"f".to_vec()]
+    );
+
+    // The filter should have been called once per SST (3 times)
+    assert_eq!(filter_call_count.load(Ordering::Relaxed), 3);
+}


### PR DESCRIPTION
## Summary

Adds Rust bindings for RocksDB's `table_filter` on `ReadOptions`, allowing iterator scans to skip entire SST files based on their table properties.

Supersedes #20 (rebased onto `restate-0.46.0`).

### Changes
- **RocksDB submodule**: Updated to include new `rocksdb_readoptions_set_table_filter` C binding in `restate.h`/`restate.cc`
- **`table_properties::TableProperties`**: Borrowed wrapper for use in filter callbacks
- **`ReadOptions::set_table_filter<F>`**: Generic method with `Send + Sync + 'static` bound
- **Integration test**: Verifies SST skipping via user-collected properties

This is useful for speeding up scans when combined with custom `TablePropertiesCollector`s — the filter callback can inspect user-collected properties to decide whether to scan each SST file.